### PR TITLE
Add persistent session-based auth adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,9 @@
 # Assumes the Postgres server was started using the Compose file in docker/postgres/docker-compose.yml
 DATABASE_URL=postgres://postgres:@localhost:5432/compass
 
-NEXTAUTH_SECRET=  # Generate using `openssl rand -base64 32`
+# This should be a long random string in production
+# One way to generate a suitable value is using `openssl rand -base64 32`
+# NEXTAUTH_SECRET=
 
 # Only needed if you want to use sign in with Google
 # GOOGLE_CLIENT_ID=

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Assumes the Postgres server was started using the Compose file in docker/postgres/docker-compose.yml
 DATABASE_URL=postgres://postgres:@localhost:5432/compass
 
-NEXTAUTH_SECRET=example-secret # Generate using `openssl rand -base64 32`
+NEXTAUTH_SECRET=  # Generate using `openssl rand -base64 32`
 
 # Only needed if you want to use sign in with Google
 # GOOGLE_CLIENT_ID=

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Assumes the Postgres server was started using the Compose file in docker/postgres/docker-compose.yml
 DATABASE_URL=postgres://postgres:@localhost:5432/compass
 
-NEXTAUTH_SECRET=example-secret # this should be a long random string in production
+NEXTAUTH_SECRET=example-secret # Generate using `openssl rand -base64 32`
 
 # Only needed if you want to use sign in with Google
 # GOOGLE_CLIENT_ID=

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Assumes the Postgres server was started using the Compose file in docker/postgres/docker-compose.yml
 DATABASE_URL=postgres://postgres:@localhost:5432/compass
 
+NEXTAUTH_SECRET=example-secret # this should be a long random string in production
+
 # Only needed if you want to use sign in with Google
 # GOOGLE_CLIENT_ID=
 # GOOGLE_CLIENT_SECRET=

--- a/src/backend/auth/adapter.ts
+++ b/src/backend/auth/adapter.ts
@@ -24,6 +24,13 @@ const mapStoredSessionToAdapterSession = (
   expires: session.expires_at,
 });
 
+/**
+ * Factory function to create a custom Auth.js adapter.
+ * At time of writing, there isn't an official adapter that works with our setup.
+ * Having a custom adapter also gives us more control over the User model.
+ *
+ * See https://next-auth.js.org/tutorials/creating-a-database-adapter
+ */
 export const createPersistedAuthAdapter = (
   db: KyselyDatabaseInstance
 ): Adapter => ({
@@ -39,6 +46,7 @@ export const createPersistedAuthAdapter = (
         last_name,
         email: user.email,
         email_verified_at: user.emailVerified,
+        // todo: this should be pulled from an invite or something else instead of defaulting to a para
         role: "para",
         image_url: user.image,
       })

--- a/src/backend/auth/adapter.ts
+++ b/src/backend/auth/adapter.ts
@@ -1,0 +1,195 @@
+import { Adapter, AdapterSession, AdapterUser } from "next-auth/adapters";
+import {
+  KyselyDatabaseInstance,
+  KyselySchema,
+  ZapatosTableNameToKyselySchema,
+} from "../lib";
+import { InsertObject, Selectable } from "kysely";
+
+const mapStoredUserToAdapterUser = (
+  user: Selectable<ZapatosTableNameToKyselySchema<"user">>
+): AdapterUser => ({
+  id: user.user_id,
+  email: user.email,
+  emailVerified: user.email_verified_at,
+  name: `${user.first_name} ${user.last_name}`,
+  image: user.image_url,
+});
+
+const mapStoredSessionToAdapterSession = (
+  session: Selectable<ZapatosTableNameToKyselySchema<"session">>
+): AdapterSession => ({
+  sessionToken: session.session_token,
+  userId: session.user_id,
+  expires: session.expires_at,
+});
+
+export const createPersistedAuthAdapter = (
+  db: KyselyDatabaseInstance
+): Adapter => ({
+  async createUser(user) {
+    const [first_name, last_name] = user.name?.split(" ") ?? [
+      user.email?.split("@")[0],
+      "",
+    ];
+    const createdUser = await db
+      .insertInto("user")
+      .values({
+        first_name,
+        last_name,
+        email: user.email,
+        email_verified_at: user.emailVerified,
+        role: "para",
+        image_url: user.image,
+      })
+      .onConflict((b) => b.column("email").doNothing())
+      .returningAll()
+      .executeTakeFirstOrThrow();
+
+    return mapStoredUserToAdapterUser(createdUser);
+  },
+  async getUser(id) {
+    const user = await db
+      .selectFrom("user")
+      .where("user_id", "=", id)
+      .selectAll()
+      .executeTakeFirstOrThrow();
+    return mapStoredUserToAdapterUser(user);
+  },
+  async getUserByEmail(email) {
+    const user = await db
+      .selectFrom("user")
+      .where("email", "=", email)
+      .selectAll()
+      .executeTakeFirst();
+    return user ? mapStoredUserToAdapterUser(user) : null;
+  },
+  async getUserByAccount({ providerAccountId, provider }) {
+    const user = await db
+      .selectFrom("user")
+      .innerJoin("account", "account.user_id", "user.user_id")
+      .where("account.provider_account_id", "=", providerAccountId)
+      .where("account.provider_name", "=", provider)
+      .selectAll("user")
+      .executeTakeFirst();
+    return user ? mapStoredUserToAdapterUser(user) : null;
+  },
+  async updateUser(user) {
+    const [first_name, last_name] = user.name?.split(" ") ?? [
+      user.email?.split("@")[0],
+      "",
+    ];
+
+    let updatedUser: Selectable<ZapatosTableNameToKyselySchema<"user">>;
+    if (user.id) {
+      updatedUser = await db
+        .updateTable("user")
+        .set({
+          email: user.email,
+          email_verified_at: user.emailVerified,
+          first_name,
+          last_name,
+          image_url: user.image,
+        })
+        .where("user_id", "=", user.id)
+        .returningAll()
+        .executeTakeFirstOrThrow();
+    } else if (user.email) {
+      updatedUser = await db
+        .updateTable("user")
+        .set({
+          email_verified_at: user.emailVerified,
+          first_name,
+          last_name,
+          image_url: user.image,
+        })
+        .where("email", "=", user.email)
+        .returningAll()
+        .executeTakeFirstOrThrow();
+    } else {
+      throw new Error("User must have an id or email");
+    }
+
+    return mapStoredUserToAdapterUser(updatedUser);
+  },
+  async deleteUser(userId) {
+    await db.deleteFrom("user").where("user_id", "=", userId).execute();
+  },
+  async linkAccount(account) {
+    const data: InsertObject<KyselySchema, "account"> = {
+      user_id: account.userId,
+      provider_name: account.provider,
+      provider_account_id: account.providerAccountId,
+      access_token: account.access_token,
+      refresh_token: account.refresh_token,
+      expires_at: account.expires_at,
+      token_type: account.token_type,
+      scope: account.scope,
+      id_token: account.id_token,
+      session_state: account.session_state,
+    };
+
+    await db
+      .insertInto("account")
+      .values(data)
+      .onConflict((b) =>
+        b.columns(["provider_name", "provider_account_id"]).doUpdateSet(data)
+      )
+      .execute();
+  },
+  async unlinkAccount({ providerAccountId, provider }) {
+    await db
+      .deleteFrom("account")
+      .where("provider_account_id", "=", providerAccountId)
+      .where("provider_name", "=", provider)
+      .execute();
+  },
+  async createSession({ sessionToken, userId, expires }) {
+    const session = await db
+      .insertInto("session")
+      .values({
+        session_token: sessionToken,
+        user_id: userId,
+        expires_at: expires,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+
+    return mapStoredSessionToAdapterSession(session);
+  },
+  async getSessionAndUser(sessionToken) {
+    const sessionAndUser = await db
+      .selectFrom("session")
+      .innerJoin("user", "user.user_id", "session.user_id")
+      .where("session_token", "=", sessionToken)
+      .selectAll()
+      .executeTakeFirstOrThrow();
+
+    if (sessionAndUser) {
+      return {
+        session: mapStoredSessionToAdapterSession(sessionAndUser),
+        user: mapStoredUserToAdapterUser(sessionAndUser),
+      };
+    }
+
+    return null;
+  },
+  async updateSession(session) {
+    const updatedSession = await db
+      .updateTable("session")
+      .set({
+        expires_at: session.expires,
+      })
+      .where("session_token", "=", session.sessionToken)
+      .returningAll()
+      .executeTakeFirstOrThrow();
+
+    return mapStoredSessionToAdapterSession(updatedSession);
+  },
+  async deleteSession(sessionToken) {
+    await db
+      .deleteFrom("session")
+      .where("session_token", "=", sessionToken)
+      .execute();
+  },
+});

--- a/src/backend/db/migrations/1_initial-migrations.sql
+++ b/src/backend/db/migrations/1_initial-migrations.sql
@@ -10,6 +10,8 @@ CREATE TABLE "user" (
   image_url TEXT
 );
 
+-- This table is managed by Auth.js via our adapter at backend/auth/adapter.ts
+-- See https://authjs.dev/reference/adapters#models for more details
 CREATE TABLE "account" (
   account_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   user_id UUID REFERENCES "user" (user_id) ON DELETE CASCADE,

--- a/src/backend/db/migrations/1_initial-migrations.sql
+++ b/src/backend/db/migrations/1_initial-migrations.sql
@@ -4,7 +4,32 @@ CREATE TABLE "user" (
   user_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   first_name TEXT NOT NULL,
   last_name TEXT NOT NULL,
-  role TEXT NOT NULL CHECK (role IN ('para', 'case_manager', 'admin'))
+  role TEXT NOT NULL CHECK (role IN ('para', 'case_manager', 'admin')),
+  email TEXT UNIQUE NOT NULL,
+  email_verified_at TIMESTAMPTZ,
+  image_url TEXT
+);
+
+CREATE TABLE "account" (
+  account_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id UUID REFERENCES "user" (user_id) ON DELETE CASCADE,
+  provider_name TEXT NOT NULL,
+  provider_account_id TEXT NOT NULL,
+  access_token TEXT,
+  refresh_token TEXT,
+  expires_at INT,
+  token_type TEXT,
+  scope TEXT,
+  id_token TEXT,
+  session_state TEXT,
+  UNIQUE (provider_name, provider_account_id)
+);
+
+CREATE TABLE "session" (
+  session_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  session_token TEXT NOT NULL UNIQUE,
+  user_id UUID NOT NULL REFERENCES "user" (user_id) ON DELETE CASCADE,
+  expires_at TIMESTAMPTZ NOT NULL
 );
 
 CREATE TABLE "student" (

--- a/src/backend/db/zapatos/schema.d.ts
+++ b/src/backend/db/zapatos/schema.d.ts
@@ -23,6 +23,623 @@ declare module "zapatos/schema" {
   /* --- tables --- */
 
   /**
+   * **account**
+   * - Table in database
+   */
+  export namespace account {
+    export type Table = "account";
+    export interface Selectable {
+      /**
+       * **account.account_id**
+       * - `uuid` in database
+       * - `NOT NULL`, default: `uuid_generate_v4()`
+       */
+      account_id: string;
+      /**
+       * **account.user_id**
+       * - `uuid` in database
+       * - Nullable, no default
+       */
+      user_id: string | null;
+      /**
+       * **account.provider_name**
+       * - `text` in database
+       * - `NOT NULL`, no default
+       */
+      provider_name: string;
+      /**
+       * **account.provider_account_id**
+       * - `text` in database
+       * - `NOT NULL`, no default
+       */
+      provider_account_id: string;
+      /**
+       * **account.access_token**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      access_token: string | null;
+      /**
+       * **account.refresh_token**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      refresh_token: string | null;
+      /**
+       * **account.expires_at**
+       * - `int4` in database
+       * - Nullable, no default
+       */
+      expires_at: number | null;
+      /**
+       * **account.token_type**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      token_type: string | null;
+      /**
+       * **account.scope**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      scope: string | null;
+      /**
+       * **account.id_token**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      id_token: string | null;
+      /**
+       * **account.session_state**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      session_state: string | null;
+    }
+    export interface JSONSelectable {
+      /**
+       * **account.account_id**
+       * - `uuid` in database
+       * - `NOT NULL`, default: `uuid_generate_v4()`
+       */
+      account_id: string;
+      /**
+       * **account.user_id**
+       * - `uuid` in database
+       * - Nullable, no default
+       */
+      user_id: string | null;
+      /**
+       * **account.provider_name**
+       * - `text` in database
+       * - `NOT NULL`, no default
+       */
+      provider_name: string;
+      /**
+       * **account.provider_account_id**
+       * - `text` in database
+       * - `NOT NULL`, no default
+       */
+      provider_account_id: string;
+      /**
+       * **account.access_token**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      access_token: string | null;
+      /**
+       * **account.refresh_token**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      refresh_token: string | null;
+      /**
+       * **account.expires_at**
+       * - `int4` in database
+       * - Nullable, no default
+       */
+      expires_at: number | null;
+      /**
+       * **account.token_type**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      token_type: string | null;
+      /**
+       * **account.scope**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      scope: string | null;
+      /**
+       * **account.id_token**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      id_token: string | null;
+      /**
+       * **account.session_state**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      session_state: string | null;
+    }
+    export interface Whereable {
+      /**
+       * **account.account_id**
+       * - `uuid` in database
+       * - `NOT NULL`, default: `uuid_generate_v4()`
+       */
+      account_id?:
+        | string
+        | db.Parameter<string>
+        | db.SQLFragment
+        | db.ParentColumn
+        | db.SQLFragment<
+            any,
+            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
+          >;
+      /**
+       * **account.user_id**
+       * - `uuid` in database
+       * - Nullable, no default
+       */
+      user_id?:
+        | string
+        | db.Parameter<string>
+        | db.SQLFragment
+        | db.ParentColumn
+        | db.SQLFragment<
+            any,
+            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
+          >;
+      /**
+       * **account.provider_name**
+       * - `text` in database
+       * - `NOT NULL`, no default
+       */
+      provider_name?:
+        | string
+        | db.Parameter<string>
+        | db.SQLFragment
+        | db.ParentColumn
+        | db.SQLFragment<
+            any,
+            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
+          >;
+      /**
+       * **account.provider_account_id**
+       * - `text` in database
+       * - `NOT NULL`, no default
+       */
+      provider_account_id?:
+        | string
+        | db.Parameter<string>
+        | db.SQLFragment
+        | db.ParentColumn
+        | db.SQLFragment<
+            any,
+            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
+          >;
+      /**
+       * **account.access_token**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      access_token?:
+        | string
+        | db.Parameter<string>
+        | db.SQLFragment
+        | db.ParentColumn
+        | db.SQLFragment<
+            any,
+            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
+          >;
+      /**
+       * **account.refresh_token**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      refresh_token?:
+        | string
+        | db.Parameter<string>
+        | db.SQLFragment
+        | db.ParentColumn
+        | db.SQLFragment<
+            any,
+            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
+          >;
+      /**
+       * **account.expires_at**
+       * - `int4` in database
+       * - Nullable, no default
+       */
+      expires_at?:
+        | number
+        | db.Parameter<number>
+        | db.SQLFragment
+        | db.ParentColumn
+        | db.SQLFragment<
+            any,
+            number | db.Parameter<number> | db.SQLFragment | db.ParentColumn
+          >;
+      /**
+       * **account.token_type**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      token_type?:
+        | string
+        | db.Parameter<string>
+        | db.SQLFragment
+        | db.ParentColumn
+        | db.SQLFragment<
+            any,
+            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
+          >;
+      /**
+       * **account.scope**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      scope?:
+        | string
+        | db.Parameter<string>
+        | db.SQLFragment
+        | db.ParentColumn
+        | db.SQLFragment<
+            any,
+            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
+          >;
+      /**
+       * **account.id_token**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      id_token?:
+        | string
+        | db.Parameter<string>
+        | db.SQLFragment
+        | db.ParentColumn
+        | db.SQLFragment<
+            any,
+            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
+          >;
+      /**
+       * **account.session_state**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      session_state?:
+        | string
+        | db.Parameter<string>
+        | db.SQLFragment
+        | db.ParentColumn
+        | db.SQLFragment<
+            any,
+            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
+          >;
+    }
+    export interface Insertable {
+      /**
+       * **account.account_id**
+       * - `uuid` in database
+       * - `NOT NULL`, default: `uuid_generate_v4()`
+       */
+      account_id?:
+        | string
+        | db.Parameter<string>
+        | db.DefaultType
+        | db.SQLFragment;
+      /**
+       * **account.user_id**
+       * - `uuid` in database
+       * - Nullable, no default
+       */
+      user_id?:
+        | string
+        | db.Parameter<string>
+        | null
+        | db.DefaultType
+        | db.SQLFragment;
+      /**
+       * **account.provider_name**
+       * - `text` in database
+       * - `NOT NULL`, no default
+       */
+      provider_name: string | db.Parameter<string> | db.SQLFragment;
+      /**
+       * **account.provider_account_id**
+       * - `text` in database
+       * - `NOT NULL`, no default
+       */
+      provider_account_id: string | db.Parameter<string> | db.SQLFragment;
+      /**
+       * **account.access_token**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      access_token?:
+        | string
+        | db.Parameter<string>
+        | null
+        | db.DefaultType
+        | db.SQLFragment;
+      /**
+       * **account.refresh_token**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      refresh_token?:
+        | string
+        | db.Parameter<string>
+        | null
+        | db.DefaultType
+        | db.SQLFragment;
+      /**
+       * **account.expires_at**
+       * - `int4` in database
+       * - Nullable, no default
+       */
+      expires_at?:
+        | number
+        | db.Parameter<number>
+        | null
+        | db.DefaultType
+        | db.SQLFragment;
+      /**
+       * **account.token_type**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      token_type?:
+        | string
+        | db.Parameter<string>
+        | null
+        | db.DefaultType
+        | db.SQLFragment;
+      /**
+       * **account.scope**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      scope?:
+        | string
+        | db.Parameter<string>
+        | null
+        | db.DefaultType
+        | db.SQLFragment;
+      /**
+       * **account.id_token**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      id_token?:
+        | string
+        | db.Parameter<string>
+        | null
+        | db.DefaultType
+        | db.SQLFragment;
+      /**
+       * **account.session_state**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      session_state?:
+        | string
+        | db.Parameter<string>
+        | null
+        | db.DefaultType
+        | db.SQLFragment;
+    }
+    export interface Updatable {
+      /**
+       * **account.account_id**
+       * - `uuid` in database
+       * - `NOT NULL`, default: `uuid_generate_v4()`
+       */
+      account_id?:
+        | string
+        | db.Parameter<string>
+        | db.DefaultType
+        | db.SQLFragment
+        | db.SQLFragment<
+            any,
+            string | db.Parameter<string> | db.DefaultType | db.SQLFragment
+          >;
+      /**
+       * **account.user_id**
+       * - `uuid` in database
+       * - Nullable, no default
+       */
+      user_id?:
+        | string
+        | db.Parameter<string>
+        | null
+        | db.DefaultType
+        | db.SQLFragment
+        | db.SQLFragment<
+            any,
+            | string
+            | db.Parameter<string>
+            | null
+            | db.DefaultType
+            | db.SQLFragment
+          >;
+      /**
+       * **account.provider_name**
+       * - `text` in database
+       * - `NOT NULL`, no default
+       */
+      provider_name?:
+        | string
+        | db.Parameter<string>
+        | db.SQLFragment
+        | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
+      /**
+       * **account.provider_account_id**
+       * - `text` in database
+       * - `NOT NULL`, no default
+       */
+      provider_account_id?:
+        | string
+        | db.Parameter<string>
+        | db.SQLFragment
+        | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
+      /**
+       * **account.access_token**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      access_token?:
+        | string
+        | db.Parameter<string>
+        | null
+        | db.DefaultType
+        | db.SQLFragment
+        | db.SQLFragment<
+            any,
+            | string
+            | db.Parameter<string>
+            | null
+            | db.DefaultType
+            | db.SQLFragment
+          >;
+      /**
+       * **account.refresh_token**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      refresh_token?:
+        | string
+        | db.Parameter<string>
+        | null
+        | db.DefaultType
+        | db.SQLFragment
+        | db.SQLFragment<
+            any,
+            | string
+            | db.Parameter<string>
+            | null
+            | db.DefaultType
+            | db.SQLFragment
+          >;
+      /**
+       * **account.expires_at**
+       * - `int4` in database
+       * - Nullable, no default
+       */
+      expires_at?:
+        | number
+        | db.Parameter<number>
+        | null
+        | db.DefaultType
+        | db.SQLFragment
+        | db.SQLFragment<
+            any,
+            | number
+            | db.Parameter<number>
+            | null
+            | db.DefaultType
+            | db.SQLFragment
+          >;
+      /**
+       * **account.token_type**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      token_type?:
+        | string
+        | db.Parameter<string>
+        | null
+        | db.DefaultType
+        | db.SQLFragment
+        | db.SQLFragment<
+            any,
+            | string
+            | db.Parameter<string>
+            | null
+            | db.DefaultType
+            | db.SQLFragment
+          >;
+      /**
+       * **account.scope**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      scope?:
+        | string
+        | db.Parameter<string>
+        | null
+        | db.DefaultType
+        | db.SQLFragment
+        | db.SQLFragment<
+            any,
+            | string
+            | db.Parameter<string>
+            | null
+            | db.DefaultType
+            | db.SQLFragment
+          >;
+      /**
+       * **account.id_token**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      id_token?:
+        | string
+        | db.Parameter<string>
+        | null
+        | db.DefaultType
+        | db.SQLFragment
+        | db.SQLFragment<
+            any,
+            | string
+            | db.Parameter<string>
+            | null
+            | db.DefaultType
+            | db.SQLFragment
+          >;
+      /**
+       * **account.session_state**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      session_state?:
+        | string
+        | db.Parameter<string>
+        | null
+        | db.DefaultType
+        | db.SQLFragment
+        | db.SQLFragment<
+            any,
+            | string
+            | db.Parameter<string>
+            | null
+            | db.DefaultType
+            | db.SQLFragment
+          >;
+    }
+    export type UniqueIndex =
+      | "account_pkey"
+      | "account_provider_name_provider_account_id_key";
+    export type Column = keyof Selectable;
+    export type OnlyCols<T extends readonly Column[]> = Pick<
+      Selectable,
+      T[number]
+    >;
+    export type SQLExpression =
+      | Table
+      | db.ColumnNames<Updatable | (keyof Updatable)[]>
+      | db.ColumnValues<Updatable>
+      | Whereable
+      | Column
+      | db.ParentColumn
+      | db.GenericSQLExpression;
+    export type SQL = SQLExpression | SQLExpression[];
+  }
+
+  /**
    * **migrations**
    * - Table in database
    */
@@ -224,6 +841,226 @@ declare module "zapatos/schema" {
           >;
     }
     export type UniqueIndex = "migrations_name_key" | "migrations_pkey";
+    export type Column = keyof Selectable;
+    export type OnlyCols<T extends readonly Column[]> = Pick<
+      Selectable,
+      T[number]
+    >;
+    export type SQLExpression =
+      | Table
+      | db.ColumnNames<Updatable | (keyof Updatable)[]>
+      | db.ColumnValues<Updatable>
+      | Whereable
+      | Column
+      | db.ParentColumn
+      | db.GenericSQLExpression;
+    export type SQL = SQLExpression | SQLExpression[];
+  }
+
+  /**
+   * **session**
+   * - Table in database
+   */
+  export namespace session {
+    export type Table = "session";
+    export interface Selectable {
+      /**
+       * **session.session_id**
+       * - `uuid` in database
+       * - `NOT NULL`, default: `uuid_generate_v4()`
+       */
+      session_id: string;
+      /**
+       * **session.session_token**
+       * - `text` in database
+       * - `NOT NULL`, no default
+       */
+      session_token: string;
+      /**
+       * **session.user_id**
+       * - `uuid` in database
+       * - `NOT NULL`, no default
+       */
+      user_id: string;
+      /**
+       * **session.expires_at**
+       * - `timestamptz` in database
+       * - `NOT NULL`, no default
+       */
+      expires_at: Date;
+    }
+    export interface JSONSelectable {
+      /**
+       * **session.session_id**
+       * - `uuid` in database
+       * - `NOT NULL`, default: `uuid_generate_v4()`
+       */
+      session_id: string;
+      /**
+       * **session.session_token**
+       * - `text` in database
+       * - `NOT NULL`, no default
+       */
+      session_token: string;
+      /**
+       * **session.user_id**
+       * - `uuid` in database
+       * - `NOT NULL`, no default
+       */
+      user_id: string;
+      /**
+       * **session.expires_at**
+       * - `timestamptz` in database
+       * - `NOT NULL`, no default
+       */
+      expires_at: db.TimestampTzString;
+    }
+    export interface Whereable {
+      /**
+       * **session.session_id**
+       * - `uuid` in database
+       * - `NOT NULL`, default: `uuid_generate_v4()`
+       */
+      session_id?:
+        | string
+        | db.Parameter<string>
+        | db.SQLFragment
+        | db.ParentColumn
+        | db.SQLFragment<
+            any,
+            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
+          >;
+      /**
+       * **session.session_token**
+       * - `text` in database
+       * - `NOT NULL`, no default
+       */
+      session_token?:
+        | string
+        | db.Parameter<string>
+        | db.SQLFragment
+        | db.ParentColumn
+        | db.SQLFragment<
+            any,
+            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
+          >;
+      /**
+       * **session.user_id**
+       * - `uuid` in database
+       * - `NOT NULL`, no default
+       */
+      user_id?:
+        | string
+        | db.Parameter<string>
+        | db.SQLFragment
+        | db.ParentColumn
+        | db.SQLFragment<
+            any,
+            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
+          >;
+      /**
+       * **session.expires_at**
+       * - `timestamptz` in database
+       * - `NOT NULL`, no default
+       */
+      expires_at?:
+        | (db.TimestampTzString | Date)
+        | db.Parameter<db.TimestampTzString | Date>
+        | db.SQLFragment
+        | db.ParentColumn
+        | db.SQLFragment<
+            any,
+            | (db.TimestampTzString | Date)
+            | db.Parameter<db.TimestampTzString | Date>
+            | db.SQLFragment
+            | db.ParentColumn
+          >;
+    }
+    export interface Insertable {
+      /**
+       * **session.session_id**
+       * - `uuid` in database
+       * - `NOT NULL`, default: `uuid_generate_v4()`
+       */
+      session_id?:
+        | string
+        | db.Parameter<string>
+        | db.DefaultType
+        | db.SQLFragment;
+      /**
+       * **session.session_token**
+       * - `text` in database
+       * - `NOT NULL`, no default
+       */
+      session_token: string | db.Parameter<string> | db.SQLFragment;
+      /**
+       * **session.user_id**
+       * - `uuid` in database
+       * - `NOT NULL`, no default
+       */
+      user_id: string | db.Parameter<string> | db.SQLFragment;
+      /**
+       * **session.expires_at**
+       * - `timestamptz` in database
+       * - `NOT NULL`, no default
+       */
+      expires_at:
+        | (db.TimestampTzString | Date)
+        | db.Parameter<db.TimestampTzString | Date>
+        | db.SQLFragment;
+    }
+    export interface Updatable {
+      /**
+       * **session.session_id**
+       * - `uuid` in database
+       * - `NOT NULL`, default: `uuid_generate_v4()`
+       */
+      session_id?:
+        | string
+        | db.Parameter<string>
+        | db.DefaultType
+        | db.SQLFragment
+        | db.SQLFragment<
+            any,
+            string | db.Parameter<string> | db.DefaultType | db.SQLFragment
+          >;
+      /**
+       * **session.session_token**
+       * - `text` in database
+       * - `NOT NULL`, no default
+       */
+      session_token?:
+        | string
+        | db.Parameter<string>
+        | db.SQLFragment
+        | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
+      /**
+       * **session.user_id**
+       * - `uuid` in database
+       * - `NOT NULL`, no default
+       */
+      user_id?:
+        | string
+        | db.Parameter<string>
+        | db.SQLFragment
+        | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
+      /**
+       * **session.expires_at**
+       * - `timestamptz` in database
+       * - `NOT NULL`, no default
+       */
+      expires_at?:
+        | (db.TimestampTzString | Date)
+        | db.Parameter<db.TimestampTzString | Date>
+        | db.SQLFragment
+        | db.SQLFragment<
+            any,
+            | (db.TimestampTzString | Date)
+            | db.Parameter<db.TimestampTzString | Date>
+            | db.SQLFragment
+          >;
+    }
+    export type UniqueIndex = "session_pkey" | "session_session_token_key";
     export type Column = keyof Selectable;
     export type OnlyCols<T extends readonly Column[]> = Pick<
       Selectable,
@@ -494,6 +1331,24 @@ declare module "zapatos/schema" {
        * - `NOT NULL`, no default
        */
       role: string;
+      /**
+       * **user.email**
+       * - `text` in database
+       * - `NOT NULL`, no default
+       */
+      email: string;
+      /**
+       * **user.email_verified_at**
+       * - `timestamptz` in database
+       * - Nullable, no default
+       */
+      email_verified_at: Date | null;
+      /**
+       * **user.image_url**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      image_url: string | null;
     }
     export interface JSONSelectable {
       /**
@@ -520,6 +1375,24 @@ declare module "zapatos/schema" {
        * - `NOT NULL`, no default
        */
       role: string;
+      /**
+       * **user.email**
+       * - `text` in database
+       * - `NOT NULL`, no default
+       */
+      email: string;
+      /**
+       * **user.email_verified_at**
+       * - `timestamptz` in database
+       * - Nullable, no default
+       */
+      email_verified_at: db.TimestampTzString | null;
+      /**
+       * **user.image_url**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      image_url: string | null;
     }
     export interface Whereable {
       /**
@@ -578,6 +1451,51 @@ declare module "zapatos/schema" {
             any,
             string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
           >;
+      /**
+       * **user.email**
+       * - `text` in database
+       * - `NOT NULL`, no default
+       */
+      email?:
+        | string
+        | db.Parameter<string>
+        | db.SQLFragment
+        | db.ParentColumn
+        | db.SQLFragment<
+            any,
+            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
+          >;
+      /**
+       * **user.email_verified_at**
+       * - `timestamptz` in database
+       * - Nullable, no default
+       */
+      email_verified_at?:
+        | (db.TimestampTzString | Date)
+        | db.Parameter<db.TimestampTzString | Date>
+        | db.SQLFragment
+        | db.ParentColumn
+        | db.SQLFragment<
+            any,
+            | (db.TimestampTzString | Date)
+            | db.Parameter<db.TimestampTzString | Date>
+            | db.SQLFragment
+            | db.ParentColumn
+          >;
+      /**
+       * **user.image_url**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      image_url?:
+        | string
+        | db.Parameter<string>
+        | db.SQLFragment
+        | db.ParentColumn
+        | db.SQLFragment<
+            any,
+            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
+          >;
     }
     export interface Insertable {
       /**
@@ -604,6 +1522,34 @@ declare module "zapatos/schema" {
        * - `NOT NULL`, no default
        */
       role: string | db.Parameter<string> | db.SQLFragment;
+      /**
+       * **user.email**
+       * - `text` in database
+       * - `NOT NULL`, no default
+       */
+      email: string | db.Parameter<string> | db.SQLFragment;
+      /**
+       * **user.email_verified_at**
+       * - `timestamptz` in database
+       * - Nullable, no default
+       */
+      email_verified_at?:
+        | (db.TimestampTzString | Date)
+        | db.Parameter<db.TimestampTzString | Date>
+        | null
+        | db.DefaultType
+        | db.SQLFragment;
+      /**
+       * **user.image_url**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      image_url?:
+        | string
+        | db.Parameter<string>
+        | null
+        | db.DefaultType
+        | db.SQLFragment;
     }
     export interface Updatable {
       /**
@@ -650,8 +1596,56 @@ declare module "zapatos/schema" {
         | db.Parameter<string>
         | db.SQLFragment
         | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
+      /**
+       * **user.email**
+       * - `text` in database
+       * - `NOT NULL`, no default
+       */
+      email?:
+        | string
+        | db.Parameter<string>
+        | db.SQLFragment
+        | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
+      /**
+       * **user.email_verified_at**
+       * - `timestamptz` in database
+       * - Nullable, no default
+       */
+      email_verified_at?:
+        | (db.TimestampTzString | Date)
+        | db.Parameter<db.TimestampTzString | Date>
+        | null
+        | db.DefaultType
+        | db.SQLFragment
+        | db.SQLFragment<
+            any,
+            | (db.TimestampTzString | Date)
+            | db.Parameter<db.TimestampTzString | Date>
+            | null
+            | db.DefaultType
+            | db.SQLFragment
+          >;
+      /**
+       * **user.image_url**
+       * - `text` in database
+       * - Nullable, no default
+       */
+      image_url?:
+        | string
+        | db.Parameter<string>
+        | null
+        | db.DefaultType
+        | db.SQLFragment
+        | db.SQLFragment<
+            any,
+            | string
+            | db.Parameter<string>
+            | null
+            | db.DefaultType
+            | db.SQLFragment
+          >;
     }
-    export type UniqueIndex = "user_pkey";
+    export type UniqueIndex = "user_email_key" | "user_pkey";
     export type Column = keyof Selectable;
     export type OnlyCols<T extends readonly Column[]> = Pick<
       Selectable,
@@ -671,39 +1665,69 @@ declare module "zapatos/schema" {
   /* --- aggregate types --- */
 
   export namespace public {
-    export type Table = migrations.Table | student.Table | user.Table;
+    export type Table =
+      | account.Table
+      | migrations.Table
+      | session.Table
+      | student.Table
+      | user.Table;
     export type Selectable =
+      | account.Selectable
       | migrations.Selectable
+      | session.Selectable
       | student.Selectable
       | user.Selectable;
     export type JSONSelectable =
+      | account.JSONSelectable
       | migrations.JSONSelectable
+      | session.JSONSelectable
       | student.JSONSelectable
       | user.JSONSelectable;
     export type Whereable =
+      | account.Whereable
       | migrations.Whereable
+      | session.Whereable
       | student.Whereable
       | user.Whereable;
     export type Insertable =
+      | account.Insertable
       | migrations.Insertable
+      | session.Insertable
       | student.Insertable
       | user.Insertable;
     export type Updatable =
+      | account.Updatable
       | migrations.Updatable
+      | session.Updatable
       | student.Updatable
       | user.Updatable;
     export type UniqueIndex =
+      | account.UniqueIndex
       | migrations.UniqueIndex
+      | session.UniqueIndex
       | student.UniqueIndex
       | user.UniqueIndex;
-    export type Column = migrations.Column | student.Column | user.Column;
+    export type Column =
+      | account.Column
+      | migrations.Column
+      | session.Column
+      | student.Column
+      | user.Column;
 
-    export type AllBaseTables = [migrations.Table, student.Table, user.Table];
+    export type AllBaseTables = [
+      account.Table,
+      migrations.Table,
+      session.Table,
+      student.Table,
+      user.Table
+    ];
     export type AllForeignTables = [];
     export type AllViews = [];
     export type AllMaterializedViews = [];
     export type AllTablesAndViews = [
+      account.Table,
       migrations.Table,
+      session.Table,
       student.Table,
       user.Table
     ];
@@ -731,49 +1755,65 @@ declare module "zapatos/schema" {
   /* === lookups === */
 
   export type SelectableForTable<T extends Table> = {
+    account: account.Selectable;
     migrations: migrations.Selectable;
+    session: session.Selectable;
     student: student.Selectable;
     user: user.Selectable;
   }[T];
 
   export type JSONSelectableForTable<T extends Table> = {
+    account: account.JSONSelectable;
     migrations: migrations.JSONSelectable;
+    session: session.JSONSelectable;
     student: student.JSONSelectable;
     user: user.JSONSelectable;
   }[T];
 
   export type WhereableForTable<T extends Table> = {
+    account: account.Whereable;
     migrations: migrations.Whereable;
+    session: session.Whereable;
     student: student.Whereable;
     user: user.Whereable;
   }[T];
 
   export type InsertableForTable<T extends Table> = {
+    account: account.Insertable;
     migrations: migrations.Insertable;
+    session: session.Insertable;
     student: student.Insertable;
     user: user.Insertable;
   }[T];
 
   export type UpdatableForTable<T extends Table> = {
+    account: account.Updatable;
     migrations: migrations.Updatable;
+    session: session.Updatable;
     student: student.Updatable;
     user: user.Updatable;
   }[T];
 
   export type UniqueIndexForTable<T extends Table> = {
+    account: account.UniqueIndex;
     migrations: migrations.UniqueIndex;
+    session: session.UniqueIndex;
     student: student.UniqueIndex;
     user: user.UniqueIndex;
   }[T];
 
   export type ColumnForTable<T extends Table> = {
+    account: account.Column;
     migrations: migrations.Column;
+    session: session.Column;
     student: student.Column;
     user: user.Column;
   }[T];
 
   export type SQLForTable<T extends Table> = {
+    account: account.SQL;
     migrations: migrations.SQL;
+    session: session.SQL;
     student: student.SQL;
     user: user.SQL;
   }[T];

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -1,14 +1,25 @@
+import { createPersistedAuthAdapter } from "@/backend/auth/adapter";
+import { createContext } from "backend/context";
+import { NextApiHandler } from "next";
 import NextAuth from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
 
-export default NextAuth({
-  // Configure one or more authentication providers
-  providers: [
-    GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID as string,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
-    }),
+const handler: NextApiHandler = (req, res) => {
+  const { db } = createContext({
+    req,
+    res,
+  });
 
-    // ...add more providers here
-  ],
-});
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  return NextAuth({
+    providers: [
+      GoogleProvider({
+        clientId: process.env.GOOGLE_CLIENT_ID as string,
+        clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
+      }),
+    ],
+    adapter: createPersistedAuthAdapter(db),
+  })(req, res);
+};
+
+export default handler;


### PR DESCRIPTION
This configures NextAuth to use a custom, persisted adapter instead of the default stateless JWT one.

This lays the groundwork for authenticating incoming requests and attaching them to a user.
