### PR TITLE
Updated README.md ordering for windows user

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,15 @@ Useful resources:
 
 1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 2. Clone the github repo:
+   - _Windows users (do this first before checkout)_ : make sure to run git autocrlf setting is set to false so that carriage return characters are not inserted into files (which breaks them when they run inside the Linux container). To do so, open a Powershell and run: `git config --global core.autocrlf false`  
+  <br>  
+  
    ```sh
    cd <parent folder of project compass>
    git clone https://github.com/sfbrigade/compass.git
    cd project-compass
    ```
-   - _Windows users_: make sure that the git autocrlf setting is set to false so that carriage return characters are not inserted into files (which breaks them when they run inside the Linux container). To do so, open a Powershell and run: `git config --global core.autocrlf false`
+   
 3. Create the local server env file:
    ```sh
    cp .env.example .env.local


### PR DESCRIPTION
Moved Windows Command `git config --global core.autocrlf false` to top prior to checking out code (As doing this after checkout will cause git to determine it as "modified" file in windows, so must do git setting prior to checkout)