### PR TITLE
Terraform configuration for ECS and related services.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ coverage
 
 # production
 build
+.terraform*
+terraform.tfstate*
 
 # misc
 .DS_Store

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,7 @@
+## Terraform workflow
+
+- Select environment: `cd terraform/staging`
+- One time setup: `terraform init`
+- Update tf files
+- Review changes: `terraform plan`
+- Apply changes: `terraform apply`

--- a/terraform/compass_module/alb.tf
+++ b/terraform/compass_module/alb.tf
@@ -1,0 +1,103 @@
+resource "aws_alb" "application_load_balancer" {
+  name               = "${var.app_name}-${var.app_environment}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  subnets            = aws_subnet.public.*.id
+  security_groups    = [aws_security_group.load_balancer_security_group.id]
+
+  tags = {
+    Name        = "${var.app_name}-alb"
+    Environment = var.app_environment
+  }
+}
+
+resource "aws_security_group" "load_balancer_security_group" {
+  vpc_id = aws_vpc.aws-vpc.id
+
+  ingress {
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+  tags = {
+    Name        = "${var.app_name}-sg"
+    Environment = var.app_environment
+  }
+}
+
+resource "aws_lb_target_group" "target_group" {
+  name        = "${var.app_name}-${var.app_environment}-tg"
+  port        = 80
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = aws_vpc.aws-vpc.id
+
+  health_check {
+    healthy_threshold   = "3"
+    interval            = "300"
+    protocol            = "HTTP"
+    matcher             = "200"
+    timeout             = "3"
+    path                = "/"
+    unhealthy_threshold = "2"
+  }
+
+  tags = {
+    Name        = "${var.app_name}-lb-tg"
+    Environment = var.app_environment
+  }
+}
+
+resource "aws_lb_listener" "listener" {
+  load_balancer_arn = aws_alb.application_load_balancer.id
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.target_group.id
+  }
+
+  # default_action {
+  #   type = "redirect"
+
+  #   redirect {
+  #     port        = "443"
+  #     protocol    = "HTTPS"
+  #     status_code = "HTTP_301"
+  #   }
+  # }
+}
+
+# resource "aws_lb_listener" "listener-https" {
+#   load_balancer_arn = aws_alb.application_load_balancer.id
+#   port              = "443"
+#   protocol          = "HTTPS"
+
+#   ssl_policy      = "ELBSecurityPolicy-2016-08"
+#   certificate_arn = "<certificate-arn>"
+
+#   default_action {
+#     target_group_arn = aws_lb_target_group.target_group.id
+#     type             = "forward"
+#   }
+# }
+

--- a/terraform/compass_module/ecr.tf
+++ b/terraform/compass_module/ecr.tf
@@ -1,0 +1,8 @@
+resource "aws_ecr_repository" "aws-ecr" {
+  name = "${var.app_name}-${var.app_environment}-ecr"
+
+  tags = {
+    Name        = "${var.app_name}-ecr"
+    Environment = var.app_environment
+  }
+}

--- a/terraform/compass_module/ecr.tf
+++ b/terraform/compass_module/ecr.tf
@@ -1,5 +1,5 @@
 resource "aws_ecr_repository" "aws-ecr" {
-  name = "${var.app_name}-${var.app_environment}-ecr"
+  name = "${var.app_name}-ecr"
 
   tags = {
     Name        = "${var.app_name}-ecr"

--- a/terraform/compass_module/ecs.tf
+++ b/terraform/compass_module/ecs.tf
@@ -1,0 +1,120 @@
+resource "aws_ecs_cluster" "aws-ecs-cluster" {
+  name = "${var.app_name}-${var.app_environment}-cluster"
+
+  tags = {
+    Name        = "${var.app_name}-ecs"
+    Environment = var.app_environment
+  }
+}
+
+resource "aws_cloudwatch_log_group" "log-group" {
+  name = "${var.app_name}-${var.app_environment}-logs"
+
+  tags = {
+    Application = var.app_name
+    Environment = var.app_environment
+  }
+}
+
+resource "aws_ecs_task_definition" "aws-ecs-task" {
+  family = "${var.app_name}-task"
+
+  container_definitions = jsonencode([
+    {
+      name      = "${var.app_name}-${var.app_environment}-container"
+      image     = "${aws_ecr_repository.aws-ecr.repository_url}:latest"
+      essential = true
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          awslogs-group         = "${aws_cloudwatch_log_group.log-group.id}",
+          awslogs-region        = "${var.aws_region}",
+          awslogs-stream-prefix = "${var.app_name}-${var.app_environment}"
+        }
+      }
+      environmentFiles = [{ type = "s3", value = "${aws_s3_bucket.env.arn}/${var.app_environment}.env" }]
+      portMappings = [
+        {
+          containerPort = 3000
+          hostPort      = 3000
+        }
+      ]
+    }
+  ])
+
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  memory                   = "512"
+  cpu                      = "256"
+  execution_role_arn       = aws_iam_role.ecsTaskExecutionRole.arn
+  task_role_arn            = aws_iam_role.ecsTaskExecutionRole.arn
+
+  tags = {
+    Name        = "${var.app_name}-ecs-td"
+    Environment = var.app_environment
+  }
+}
+
+data "aws_ecs_task_definition" "main" {
+  task_definition = aws_ecs_task_definition.aws-ecs-task.family
+}
+
+resource "aws_ecs_service" "aws-ecs-service" {
+  name                 = "${var.app_name}-${var.app_environment}-ecs-service"
+  cluster              = aws_ecs_cluster.aws-ecs-cluster.id
+  task_definition      = "${aws_ecs_task_definition.aws-ecs-task.family}:${max(aws_ecs_task_definition.aws-ecs-task.revision, data.aws_ecs_task_definition.main.revision)}"
+  launch_type          = "FARGATE"
+  scheduling_strategy  = "REPLICA"
+  desired_count        = 2
+  force_new_deployment = true
+
+  network_configuration {
+    # TODO(amantri): Ideally we would use the private subnets, but then need to define the following VPC endpoints:
+    # com.amazonaws.region.ecr.dkr
+    # com.amazonaws.region.ecr.api
+    # S3 gateway endpoint
+    # com.amazonaws.region.logs
+    # maybe secretsmanager.us-east-1.amazonaws.com
+    # If we define the VPC endpoints, uncomment these two lines:
+    # # subnets          = aws_subnet.private.*.id
+    # # assign_public_ip = false
+    subnets          = aws_subnet.public.*.id
+    assign_public_ip = true
+    security_groups = [
+      aws_security_group.service_security_group.id,
+      aws_security_group.load_balancer_security_group.id
+    ]
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.target_group.arn
+    container_name   = "${var.app_name}-${var.app_environment}-container"
+    container_port   = 3000
+  }
+
+  depends_on = [aws_lb_listener.listener]
+}
+
+resource "aws_security_group" "service_security_group" {
+  vpc_id = aws_vpc.aws-vpc.id
+
+  ingress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    security_groups = [aws_security_group.load_balancer_security_group.id]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = {
+    Name        = "${var.app_name}-service-sg"
+    Environment = var.app_environment
+  }
+}

--- a/terraform/compass_module/ecs.tf
+++ b/terraform/compass_module/ecs.tf
@@ -65,7 +65,7 @@ resource "aws_ecs_service" "aws-ecs-service" {
   task_definition      = "${aws_ecs_task_definition.aws-ecs-task.family}:${max(aws_ecs_task_definition.aws-ecs-task.revision, data.aws_ecs_task_definition.main.revision)}"
   launch_type          = "FARGATE"
   scheduling_strategy  = "REPLICA"
-  desired_count        = 2
+  desired_count        = 1
   force_new_deployment = true
 
   network_configuration {

--- a/terraform/compass_module/iam.tf
+++ b/terraform/compass_module/iam.tf
@@ -1,0 +1,48 @@
+resource "aws_iam_role" "ecsTaskExecutionRole" {
+  name               = "${var.app_name}-${var.app_environment}-execution-task-role"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+  tags = {
+    Name        = "${var.app_name}-${var.app_environment}-iam-role"
+    Environment = var.app_environment
+  }
+}
+
+data "aws_iam_policy_document" "assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecsTaskExecutionRole_policy" {
+  role       = aws_iam_role.ecsTaskExecutionRole.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+data "aws_iam_policy_document" "s3_env_policy" {
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.env.arn}/*"]
+  }
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:GetBucketLocation"]
+    resources = [aws_s3_bucket.env.arn]
+  }
+}
+
+resource "aws_iam_policy" "s3_env_policy" {
+  name        = "${var.app_name}-${var.app_environment}-s3-policy"
+  description = "Allow access to files on s3"
+  policy      = data.aws_iam_policy_document.s3_env_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "s3_env_policy_attachment" {
+  role       = aws_iam_role.ecsTaskExecutionRole.name
+  policy_arn = aws_iam_policy.s3_env_policy.arn
+}

--- a/terraform/compass_module/main.tf
+++ b/terraform/compass_module/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  # TODO(amantri): setup s3 bucket for state management.
+  # https://dev.to/thnery/create-an-aws-ecs-cluster-using-terraform-g80#terraform-initial-configuration
+  # https://courses.devopsdirective.com/terraform-beginner-to-pro/lessons/03-basic-terraform-usage/04-terraform-remote-backends#bootstrapping-process-for-aws-s3-backend
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.67"
+    }
+  }
+}
+
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_user
+}

--- a/terraform/compass_module/networking.tf
+++ b/terraform/compass_module/networking.tf
@@ -1,0 +1,68 @@
+# Creates a VPC with two public subnets, two private subnets and an internet
+# gateway
+
+resource "aws_vpc" "aws-vpc" {
+  cidr_block           = var.cidr_block
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name        = "${var.app_name}-${var.app_environment}-vpc"
+    Environment = var.app_environment
+  }
+}
+
+resource "aws_internet_gateway" "aws-igw" {
+  vpc_id = aws_vpc.aws-vpc.id
+  tags = {
+    Name        = "${var.app_name}-igw"
+    Environment = var.app_environment
+  }
+
+}
+
+resource "aws_subnet" "private" {
+  vpc_id            = aws_vpc.aws-vpc.id
+  count             = length(var.private_subnets)
+  cidr_block        = element(var.private_subnets, count.index)
+  availability_zone = element(var.availability_zones, count.index)
+
+  tags = {
+    Name        = "${var.app_name}-private-subnet-${count.index + 1}"
+    Environment = var.app_environment
+  }
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.aws-vpc.id
+  cidr_block              = element(var.public_subnets, count.index)
+  availability_zone       = element(var.availability_zones, count.index)
+  count                   = length(var.public_subnets)
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name        = "${var.app_name}-public-subnet-${count.index + 1}"
+    Environment = var.app_environment
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.aws-vpc.id
+
+  tags = {
+    Name        = "${var.app_name}-routing-table-public"
+    Environment = var.app_environment
+  }
+}
+
+resource "aws_route" "public" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.aws-igw.id
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(var.public_subnets)
+  subnet_id      = element(aws_subnet.public.*.id, count.index)
+  route_table_id = aws_route_table.public.id
+}

--- a/terraform/compass_module/s3.tf
+++ b/terraform/compass_module/s3.tf
@@ -1,0 +1,15 @@
+resource "aws_s3_bucket" "env" {
+  bucket = "${var.app_name}-env"
+
+  tags = {
+    Name        = "${var.app_name}-${var.app_environment}-s3"
+    Environment = var.app_environment
+  }
+}
+
+resource "aws_s3_bucket_versioning" "env_versioning" {
+  bucket = aws_s3_bucket.env.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}

--- a/terraform/compass_module/variables.tf
+++ b/terraform/compass_module/variables.tf
@@ -1,0 +1,39 @@
+variable "app_name" {
+  description = "Name of the deployed app, e.g. compass-prod or compass-staging"
+  type        = string
+}
+
+variable "app_environment" {
+  description = "Deployment environment for the app, e.g. prod or staging"
+  type        = string
+}
+
+variable "aws_user" {
+  type        = string
+  description = "AWS user to manage resources"
+}
+
+variable "aws_region" {
+  description = "AWS region for deployment"
+  type        = string
+}
+
+variable "availability_zones" {
+  description = "List of availability zones"
+}
+
+variable "cidr_block" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnets" {
+  description = "List of public subnets"
+  default     = ["10.0.100.0/24", "10.0.101.0/24"]
+}
+
+variable "private_subnets" {
+  description = "List of private subnets"
+  default     = ["10.0.0.0/24", "10.0.1.0/24"]
+}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -1,0 +1,11 @@
+module "compass" {
+  source = "../compass_module"
+
+  # Module input variables
+  app_name        = "compass"
+  app_environment = "staging"
+
+  aws_user           = "terraform-user"
+  aws_region         = "us-west-1"
+  availability_zones = ["us-west-1b", "us-west-1c"]
+}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -6,6 +6,6 @@ module "compass" {
   app_environment = "staging"
 
   aws_user           = "terraform-user"
-  aws_region         = "us-west-1"
-  availability_zones = ["us-west-1b", "us-west-1c"]
+  aws_region         = "us-west-2"
+  availability_zones = ["us-west-2b", "us-west-2c"]
 }


### PR DESCRIPTION
In this iteration, the secrets are read from a `staging.env` file in an S3 bucket. This level of security and convenience is likely ok for now.

Additionally, the current iteration launches the tasks in a public subnet, so as to be able to read the Docker images from the ECR. The individual instances themselves are still not accessible due to the their security group settings. If we want to launch them in a private subnet, then we would need to create VPC endpoints - the complexity might not be worth the benefits.

Postgres setup in AWS will follow in a separate PR.

#60 