### PR TITLE
Fix flaky tests

### DIFF
--- a/src/backend/routers/paras.ts
+++ b/src/backend/routers/paras.ts
@@ -6,7 +6,6 @@ export const paraProcedures = {
   getParaById: procedure
     .input(z.object({ user_id: z.string().uuid() }))
     .query(async (req) => {
-      console.log("req", req);
       const { user_id } = req.input;
 
       const result = await req.ctx.db

--- a/src/backend/tests/fixtures/get-test-nextjs.ts
+++ b/src/backend/tests/fixtures/get-test-nextjs.ts
@@ -1,0 +1,16 @@
+import { registerSharedTypeScriptWorker } from "ava-typescript-worker";
+import {
+  NextWorkerPublishedMessage,
+  NextWorkerRequestPayload,
+} from "./workers/get-test-nextjs.worker";
+
+const worker = registerSharedTypeScriptWorker({
+  filename: new URL("./workers/get-test-nextjs.worker.ts", import.meta.url),
+});
+
+export const getTestNextJs = async (payload: NextWorkerRequestPayload) => {
+  const fixture = await worker.publish(payload).replies().next();
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  return fixture.value.data as NextWorkerPublishedMessage;
+};

--- a/src/backend/tests/fixtures/workers/get-test-nextjs.worker.ts
+++ b/src/backend/tests/fixtures/workers/get-test-nextjs.worker.ts
@@ -1,0 +1,48 @@
+import { SharedWorker } from "ava/plugin";
+import next from "next";
+import { Env } from "@/backend/lib";
+import { createServer } from "node:http";
+
+const getNextRequestHandler = async () => {
+  const app = next({
+    dev: true,
+  });
+  await app.prepare();
+  return app.getRequestHandler();
+};
+
+export type NextWorkerRequestPayload = {
+  env: Env;
+  appPort: number;
+};
+
+export type NextWorkerPublishedMessage = {
+  endpoint: string;
+};
+
+const nextRequestHandlerPromise = getNextRequestHandler();
+
+const handleTestWorkers = async (protocol: SharedWorker.Protocol) => {
+  for await (const msg of protocol.subscribe()) {
+    const { env, appPort } = msg.data as NextWorkerRequestPayload;
+
+    const nextRequestHandler = await nextRequestHandlerPromise;
+    const server = createServer(async (req, res) => {
+      (req as unknown as { env: Env }).env = env;
+      await nextRequestHandler(req, res);
+    });
+
+    server.listen(appPort);
+
+    msg.testWorker.teardown(() => {
+      console.log("tearing down");
+      server.close();
+    });
+
+    msg.reply({
+      endpoint: `http://localhost:${appPort}`,
+    });
+  }
+};
+
+export default handleTestWorkers;


### PR DESCRIPTION
Use a Next.js singleton in our test fixture to prevent flaky tests. I believe it was due to multiple Next.js dev servers mutating files in `.next` concurrently under certain circumstances.

Closes https://github.com/sfbrigade/compass/issues/99.
