### PR TITLE
Flatten directory structure by moving dir/[id]/index.tsx -> dir/[id].tsx

### DIFF
--- a/src/pages/paras/[user_id].tsx
+++ b/src/pages/paras/[user_id].tsx
@@ -1,7 +1,7 @@
 import { trpc } from "client/lib/trpc";
 import { useRouter } from "next/router";
 import Link from "next/link";
-import styles from "../../../styles/Home.module.css";
+import styles from "@/styles/Home.module.css";
 
 const ViewParaPage = () => {
   const router = useRouter();

--- a/src/pages/students/[student_id].tsx
+++ b/src/pages/students/[student_id].tsx
@@ -3,7 +3,7 @@ import { trpc } from "client/lib/trpc";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import StudentIEP from "./iep";
-import styles from "../../../styles/Home.module.css";
+import styles from "@/styles/Home.module.css";
 
 const ViewStudentPage = () => {
   const [archive, setArchive] = useState(false);

--- a/src/pages/students/iep.tsx
+++ b/src/pages/students/iep.tsx
@@ -2,6 +2,8 @@ interface StudentIEPProps {
   first_name: string | undefined;
   last_name: string | undefined;
 }
+
+// TODO: Move this to the components directory
 const StudentIEP: React.FC<StudentIEPProps> = ({ first_name, last_name }) => {
   return (
     <div>


### PR DESCRIPTION
The two paths are identical for NextJs. One other benefit of this change is that we reduce the number of files called "index.tsx" which makes them easier to find in the IDE :)
