### PR TITLE
Restrict the node versions to <20.0.0 for Compass.

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=18.0.0 <20.0.0",
     "npm": ">=8.0.0"
   },
   "lint-staged": {


### PR DESCRIPTION
Tests are currently failing for node 20
