### PR TITLE
Transpile tests using a require-based loader instead of --experimental-loader

### DIFF
--- a/ava.config.js
+++ b/ava.config.js
@@ -2,6 +2,6 @@ module.exports = {
   timeout: "90s",
   files: ["src/**/*.test.ts"],
   extensions: ["ts"],
-  nodeArguments: ["--loader=tsx"],
+  require: ["@esbuild-kit/cjs-loader"],
   ignoredByWatcher: ["**/.next/**"],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "@ava/get-port": "^2.0.0",
+        "@esbuild-kit/cjs-loader": "^2.4.2",
         "@trpc/client": "^10.16.0",
         "@types/mockery": "^1.4.30",
         "@types/ms": "^0.7.31",
@@ -45,8 +46,6 @@
         "ava": "^5.1.1",
         "ava-postgres": "^3.0.0",
         "ava-typescript-worker": "^2.0.0",
-        "esbuild": "^0.17.5",
-        "esbuild-register": "^3.4.2",
         "eslint": "^8.34.0",
         "eslint-config-next": "13.1.6",
         "foreman": "^3.0.1",
@@ -57,7 +56,6 @@
         "nodemailer-mock": "^2.0.1",
         "prettier": "^2.8.8",
         "testcontainers": "^9.8.0",
-        "tsx": "^3.12.7",
         "type-fest": "^3.5.4",
         "typescript": "^4.9.5"
       },
@@ -1516,16 +1514,6 @@
       "dependencies": {
         "esbuild": "~0.17.6",
         "source-map-support": "^0.5.21"
-      }
-    },
-    "node_modules/@esbuild-kit/esm-loader": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.5.5.tgz",
-      "integrity": "sha512-Qwfvj/qoPbClxCRNuac1Du01r9gvNOT+pMYtJDapfB1eoGN1YlJ1BixLyL9WVENRx5RXgNLdfYdx/CuswlGhMw==",
-      "dev": true,
-      "dependencies": {
-        "@esbuild-kit/core-utils": "^3.0.0",
-        "get-tsconfig": "^4.4.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -4505,19 +4493,6 @@
         "@esbuild/win32-arm64": "0.17.8",
         "@esbuild/win32-ia32": "0.17.8",
         "@esbuild/win32-x64": "0.17.8"
-      }
-    },
-    "node_modules/esbuild-register": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.4.2.tgz",
-      "integrity": "sha512-kG/XyTDyz6+YDuyfB9ZoSIOOmgyFCH+xPRtsCa8W85HLRV5Csp+o3jWVbOSHgSLfyLc5DmP+KFDNwty4mEjC+Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "peerDependencies": {
-        "esbuild": ">=0.12 <1"
       }
     },
     "node_modules/esbuild-runner": {
@@ -10058,23 +10033,6 @@
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/tsx": {
-      "version": "3.12.7",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.12.7.tgz",
-      "integrity": "sha512-C2Ip+jPmqKd1GWVQDvz/Eyc6QJbGfE7NrR3fx5BpEHMZsEHoIxHL1j+lKdGobr8ovEyqeNkPLSKp6SCSOt7gmw==",
-      "dev": true,
-      "dependencies": {
-        "@esbuild-kit/cjs-loader": "^2.4.2",
-        "@esbuild-kit/core-utils": "^3.0.0",
-        "@esbuild-kit/esm-loader": "^2.5.5"
-      },
-      "bin": {
-        "tsx": "dist/cli.js"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -11981,16 +11939,6 @@
       "requires": {
         "esbuild": "~0.17.6",
         "source-map-support": "^0.5.21"
-      }
-    },
-    "@esbuild-kit/esm-loader": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.5.5.tgz",
-      "integrity": "sha512-Qwfvj/qoPbClxCRNuac1Du01r9gvNOT+pMYtJDapfB1eoGN1YlJ1BixLyL9WVENRx5RXgNLdfYdx/CuswlGhMw==",
-      "dev": true,
-      "requires": {
-        "@esbuild-kit/core-utils": "^3.0.0",
-        "get-tsconfig": "^4.4.0"
       }
     },
     "@eslint/eslintrc": {
@@ -14001,15 +13949,6 @@
         "@esbuild/win32-arm64": "0.17.8",
         "@esbuild/win32-ia32": "0.17.8",
         "@esbuild/win32-x64": "0.17.8"
-      }
-    },
-    "esbuild-register": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.4.2.tgz",
-      "integrity": "sha512-kG/XyTDyz6+YDuyfB9ZoSIOOmgyFCH+xPRtsCa8W85HLRV5Csp+o3jWVbOSHgSLfyLc5DmP+KFDNwty4mEjC+Q==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.3.4"
       }
     },
     "esbuild-runner": {
@@ -17721,18 +17660,6 @@
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         }
-      }
-    },
-    "tsx": {
-      "version": "3.12.7",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.12.7.tgz",
-      "integrity": "sha512-C2Ip+jPmqKd1GWVQDvz/Eyc6QJbGfE7NrR3fx5BpEHMZsEHoIxHL1j+lKdGobr8ovEyqeNkPLSKp6SCSOt7gmw==",
-      "dev": true,
-      "requires": {
-        "@esbuild-kit/cjs-loader": "^2.4.2",
-        "@esbuild-kit/core-utils": "^3.0.0",
-        "@esbuild-kit/esm-loader": "^2.5.5",
-        "fsevents": "~2.3.2"
       }
     },
     "tweetnacl": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@ava/get-port": "^2.0.0",
+    "@esbuild-kit/cjs-loader": "^2.4.2",
     "@trpc/client": "^10.16.0",
     "@types/mockery": "^1.4.30",
     "@types/ms": "^0.7.31",
@@ -55,8 +56,6 @@
     "ava": "^5.1.1",
     "ava-postgres": "^3.0.0",
     "ava-typescript-worker": "^2.0.0",
-    "esbuild": "^0.17.5",
-    "esbuild-register": "^3.4.2",
     "eslint": "^8.34.0",
     "eslint-config-next": "13.1.6",
     "foreman": "^3.0.1",
@@ -67,12 +66,11 @@
     "nodemailer-mock": "^2.0.1",
     "prettier": "^2.8.8",
     "testcontainers": "^9.8.0",
-    "tsx": "^3.12.7",
     "type-fest": "^3.5.4",
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": ">=18.0.0 <20.0.0",
+    "node": ">=18.0.0",
     "npm": ">=8.0.0"
   },
   "lint-staged": {


### PR DESCRIPTION
The previous loader didn't work in Node.js v20.
