### PR TITLE
Split out S3 backend for Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ coverage
 build
 .terraform*
 terraform.tfstate*
+!.terraform.lock.hcl
 
 # Ignore all .env files except .env.example
 .env*

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,1 @@
+backend.dev.hcl

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,7 +1,19 @@
-## Terraform workflow
+# Terraform
 
-- Select environment: `cd terraform/staging`
-- One time setup: `terraform init`
-- Update tf files
-- Review changes: `terraform plan`
-- Apply changes: `terraform apply`
+## Initializing a new AWS account
+
+To initialize the terraform backend (must be done once manually per AWS account):
+
+1. `cd terraform/s3-backend`
+2. `terraform init`
+2. `terraform apply -var 'bucket_name=<terraform-state-bucket-name>' -var 'dynamodb_table=<lock-table-name>'` (substitute values for bucket_name and dynamodb_table)
+
+If this is for a local development environment, copy `backend.hcl` to `backend.dev.hcl` and update `bucket` & `dynamodb_table` values with what you used above.
+
+Otherwise, update `backend.hcl` directly.
+
+## Deploying
+
+1. `cd terraform/staging`
+2. `terraform init -backend-config=../backend.dev.hcl` (you only need to run this once)
+3. `terraform apply`

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -6,7 +6,7 @@ To initialize the terraform backend (must be done once manually per AWS account)
 
 1. `cd terraform/s3-backend`
 2. `terraform init`
-2. `terraform apply -var 'bucket_name=<terraform-state-bucket-name>' -var 'dynamodb_table=<lock-table-name>'` (substitute values for bucket_name and dynamodb_table)
+3. `terraform apply -var 'bucket_name=<terraform-state-bucket-name>' -var 'dynamodb_table=<lock-table-name>'` (substitute values for bucket_name and dynamodb_table)
 
 If this is for a local development environment, copy `backend.hcl` to `backend.dev.hcl` and update `bucket` & `dynamodb_table` values with what you used above.
 

--- a/terraform/backend.hcl
+++ b/terraform/backend.hcl
@@ -1,0 +1,4 @@
+bucket         = "compass-staging-tf-state"
+region         = "us-west-2"
+dynamodb_table = "compass-staging-tf-state-locking"
+encrypt        = true

--- a/terraform/compass_module/main.tf
+++ b/terraform/compass_module/main.tf
@@ -1,8 +1,4 @@
 # Creates and manages the AWS resources needed for Compass.
-#
-# Also creates the following resources for the Terraform backend configuration:
-#  s3 bucket for state backup: "${var.app_name}-${var.app_environment}-tf-state"
-#  DynamoDB for locking      : "${var.app_name}-${var.app_environment}-tf-state-locking"
 
 terraform {
   required_providers {
@@ -15,46 +11,4 @@ terraform {
 
 provider "aws" {
   region  = var.aws_region
-  profile = var.aws_user
-}
-
-resource "aws_s3_bucket" "terraform_state" {
-  bucket        = "${var.app_name}-${var.app_environment}-tf-state"
-  force_destroy = true
-
-  tags = {
-    Name        = "${var.app_name}-${var.app_environment}-s3"
-    Environment = var.app_environment
-  }
-}
-
-resource "aws_s3_bucket_versioning" "terraform_bucket_versioning" {
-  bucket = aws_s3_bucket.terraform_state.id
-  versioning_configuration {
-    status = "Enabled"
-  }
-}
-
-resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state_crypto_conf" {
-  bucket = aws_s3_bucket.terraform_state.bucket
-  rule {
-    apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
-    }
-  }
-}
-
-resource "aws_dynamodb_table" "terraform_locks" {
-  name         = "${var.app_name}-${var.app_environment}-tf-state-locking"
-  billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "LockID"
-  attribute {
-    name = "LockID"
-    type = "S"
-  }
-
-  tags = {
-    Name        = "${var.app_name}-${var.app_environment}-dynamodb"
-    Environment = var.app_environment
-  }
 }

--- a/terraform/compass_module/variables.tf
+++ b/terraform/compass_module/variables.tf
@@ -8,11 +8,6 @@ variable "app_environment" {
   type        = string
 }
 
-variable "aws_user" {
-  type        = string
-  description = "AWS user to manage resources"
-}
-
 variable "aws_region" {
   description = "AWS region for deployment"
   type        = string

--- a/terraform/s3-backend/.terraform.lock.hcl
+++ b/terraform/s3-backend/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.8.0"
+  hashes = [
+    "h1:vnjWfeuf4AflWsRq3ivVig8dR8PAg8BHTVyAtOzJ1yQ=",
+    "zh:0974311d5e1becfdcbdae43d022d52689fdad32a4145659e56ac534bcb8cba02",
+    "zh:100dc64a90fc0d36cf6e2882b4358fde17705edd8ab3c5f2c06d219c36b21565",
+    "zh:467a86de8a7d77cde5c3386f9e82d7f1bf5972d1b3d177e797d1d9d2e87fd357",
+    "zh:4ad1f8ef5c5522f81d271b93594a43a7666b3409ca201a1911cd950e489ef12b",
+    "zh:540a50ab7061c6df2057ec9580890a9e86a687233120af738985fa84dde2a20a",
+    "zh:6e7b73b770e92891da94751c3e0cff1e1b852f5121da8c4a689056833eeb7d94",
+    "zh:879d42721e86331b05ff77bd219ca9a062485cdb2fa803d2dcf63084f25d484c",
+    "zh:980563e615fbba127c02df6dc8872ce60f7137df45fdb8cd801cdcbae6cf192a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a6ad25c4d3edde466ea68731097aedad4b68278af0742fc1ab71d2c30491f92e",
+    "zh:af8df9e06f576c11ce67ac2b675d0d8db4aac618fec95d27c10aa59436feebbf",
+    "zh:b625ca7c4b99c6b3af34041b9773ccd9d80b0dde264c40b5d163a6abd73793af",
+    "zh:c9e0ca6aa48ebaa0892ac438392c49052a86605f490950d5317855f35ab7d74a",
+    "zh:dc500a03d3ed6b1fed3f118a55a7fb93bf172965ae6b2f25cc7f4a152e44edd7",
+    "zh:e0438bf67d93a29f0d56f9a4544297155ca85c0f10626778d4c3aa68c7e93581",
+  ]
+}

--- a/terraform/s3-backend/main.tf
+++ b/terraform/s3-backend/main.tf
@@ -1,0 +1,56 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+variable "bucket_name" {
+  type = string
+}
+
+variable "dynamodb_table" {
+  type = string
+}
+
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = var.bucket_name
+
+  # Prevent accidental deletion of this S3 bucket
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "enabled" {
+  bucket = aws_s3_bucket.terraform_state.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "public_access" {
+  bucket                  = aws_s3_bucket.terraform_state.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_dynamodb_table" "terraform_locks" {
+  name         = var.dynamodb_table
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}

--- a/terraform/staging/.terraform.lock.hcl
+++ b/terraform/staging/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.67.0"
+  constraints = "~> 4.67"
+  hashes = [
+    "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
+    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
+    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
+    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
+    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
+    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
+    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
+    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
+    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
+    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
+    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
+    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
+    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
+    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
+  ]
+}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -1,10 +1,6 @@
 terraform {
   backend "s3" {
-    bucket         = "compass-staging-tf-state" # Substitute environment as needed
-    key            = "terraform.tfstate"
-    region         = "us-west-2"
-    dynamodb_table = "compass-staging-tf-state-locking" # Substitute environment as needed
-    encrypt        = true
+    key = "staging/terraform.tfstate"
   }
 }
 
@@ -15,7 +11,6 @@ module "compass" {
   app_name        = "compass"
   app_environment = "staging"
 
-  aws_user           = "terraform-user"
   aws_region         = "us-west-2"
   availability_zones = ["us-west-2b", "us-west-2c"]
 }


### PR DESCRIPTION
A few changes I needed to make to get started.

I split out the S3 backend from the main deployment as it seems like the recommendation is to deploy it once manually rather than continously to avoid the chicken and egg problem.

Also, the Terraform backend config is now in a separate file to make it easier to use a local dev environment.