### PR TITLE
Fix staging login redirect loop

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,7 +9,11 @@ import { NextRequest, NextResponse } from "next/server";
  * However, their middleware doesn't yet work with database sessions.
  */
 export function middleware(request: NextRequest) {
-  if (!request.cookies.get("next-auth.session-token")) {
+  const sessionToken =
+    request.cookies.get("next-auth.session-token") ??
+    request.cookies.get("__Secure-next-auth.session-token");
+
+  if (!sessionToken) {
     const url = request.nextUrl.clone();
     url.pathname = "/signInPage";
     return NextResponse.redirect(url);


### PR DESCRIPTION
Apparently next auth uses a different cookie name for HTTPS origins.
