### PR TITLE
BUG: Empty staff list shows student's empty state #232

### DIFF
--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -135,7 +135,7 @@ function EnhancedTableToolbar({
 }: EnhancedTableToolbarProps) {
   return (
     <>
-      {totalRows === 0 ? (
+      {totalRows === 0 && type === "Students" ? (
         <h2 className={$table.tableTitle}>{type}</h2>
       ) : (
         <Toolbar
@@ -334,7 +334,7 @@ export default function EnhancedTable<
         searchParam={searchParam}
         onSearch={handleSearch}
       />
-      {people.length === 0 && !showInput && (
+      {people.length === 0 && !showInput && type === "Students" && (
         <Container sx={{ marginTop: "4rem" }}>
           <Box
             sx={{
@@ -359,7 +359,7 @@ export default function EnhancedTable<
         </Container>
       )}
 
-      {(people.length || showInput) && (
+      {(people.length || showInput || type === "Staff") && (
         <TableContainer>
           <Table sx={{ minWidth: 750 }} aria-labelledby={`Table of ${type}s`}>
             <EnhancedTableHead


### PR DESCRIPTION
Referencing issue #232. I adjusted the specification of the empty state so Staff page shouldn't be affected by Student's list empty state anymore.

**Before:**
<img width="1507" alt="Screenshot 2023-11-03 at 10 11 17 AM" src="https://github.com/sfbrigade/compass/assets/104481165/62212b52-642f-4078-9702-e9fdd25a76cc">


**After**:
<img width="1508" alt="Screenshot 2023-11-03 at 10 09 31 AM" src="https://github.com/sfbrigade/compass/assets/104481165/c29e7a20-d062-46a4-a75c-160da012a38f">
