### PR TITLE
Staff page

### DIFF
--- a/src/backend/routers/case_manager.ts
+++ b/src/backend/routers/case_manager.ts
@@ -190,7 +190,22 @@ export const case_manager = router({
       const { para_id, first_name, last_name, email } = req.input;
       const { userId } = req.ctx.auth;
 
-      // Check if the para exists and if the case manager is assigned to the para
+      // if userId is of type "para" and userID !== para_id, then they cannot edit another para's info - throw an error
+
+      // if userId is of type "para" and userID === para_id, then they can edit their own info
+      if (userId === para_id) {
+        return await req.ctx.db
+          .updateTable("user")
+          .set({
+            first_name,
+            last_name,
+            email: email.toLowerCase(),
+          })
+          .where("user_id", "=", para_id)
+          .returningAll()
+          .executeTakeFirstOrThrow();
+      }
+      // Then at this point, continue by checking if the para exists and if the case manager is assigned to the para.
       const existingPara = req.ctx.db
         .selectFrom("user")
         .innerJoin(
@@ -201,6 +216,9 @@ export const case_manager = router({
         .where("paras_assigned_to_case_manager.case_manager_id", "=", userId)
         .selectAll();
 
+      // if userId is of type "case_manager" and they are not assigned to the para, then they cannot edit the para's (para_id) info - throw an error
+
+      // if userId is of type "case_manager" and they are assigned to the para, then they can edit the para's (para_id) info
       if (!existingPara) {
         throw new Error("Para not found");
       }

--- a/src/components/layout/Layout.module.css
+++ b/src/components/layout/Layout.module.css
@@ -19,7 +19,8 @@
   background-color: var(--primary-container);
 }
 
-.mainStudent {
+.mainStudent,
+.mainStaff {
   composes: main;
   background-color: var(--grey-80);
 }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -21,7 +21,9 @@ const Layout = ({ children }: LayoutProps) => {
       <NavBar />
       <main
         className={`${isPurpleBg ? $layout.mainPurple : $layout.main}
-        ${router.query.student_id ? $layout.mainStudent : ""}`}
+        ${router.query.student_id ? $layout.mainStudent : ""} ${
+          router.query.user_id ? $layout.mainStaff : ""
+        }`}
       >
         {children}
       </main>

--- a/src/pages/staff/[user_id].tsx
+++ b/src/pages/staff/[user_id].tsx
@@ -1,15 +1,34 @@
 import { useState } from "react";
 import { trpc } from "@/client/lib/trpc";
 import { useRouter } from "next/router";
-import Link from "next/link";
 import $home from "@/styles/Home.module.css";
 import $button from "@/styles/Button.module.css";
+import $StaffPage from "../../styles/StaffPage.module.css";
+import $Modal from "../../styles/Modal.module.css";
+
+import Stack from "@mui/material/Stack";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Container from "@mui/material/Container";
+import Modal from "@mui/material/Modal";
 
 const ViewParaPage = () => {
-  const [unassignParaPrompt, setUnassignParaPrompt] = useState(false);
+  const [archiveParaPrompt, setArchiveParaPrompt] = useState(false);
+  const [viewState, setViewState] = useState(0);
+
   const router = useRouter();
   const { user_id } = router.query;
   const { data: me } = trpc.user.getMe.useQuery();
+
+  const VIEW_STATES = { MAIN: 0, EDIT: 1 };
+
+  const handleEditState = () => {
+    setViewState(VIEW_STATES.EDIT);
+  };
+
+  const handleMainState = () => {
+    setViewState(VIEW_STATES.MAIN);
+  };
 
   const { data: para, isLoading } = trpc.para.getParaById.useQuery(
     { user_id: user_id as string },
@@ -20,7 +39,13 @@ const ViewParaPage = () => {
     }
   );
 
-  const unassignPara = trpc.case_manager.removePara.useMutation({
+  const buttonSX = {
+    "&:hover": {
+      background: "#3023B8",
+    },
+  };
+
+  const archivePara = trpc.case_manager.removePara.useMutation({
     onError: (error) => console.log(error.message),
   });
 
@@ -28,11 +53,11 @@ const ViewParaPage = () => {
     await router.push(`/staff`);
   };
 
-  const handleUnassignPara = async () => {
+  const handleArchivePara = async () => {
     if (!para) return;
 
-    await unassignPara.mutateAsync({ para_id: para.user_id });
-    await returnToStaffList();
+    await archivePara.mutateAsync({ para_id: para.user_id });
+    await router.push(`/staff`);
   };
 
   if (isLoading) {
@@ -42,50 +67,214 @@ const ViewParaPage = () => {
   if (!para) return;
 
   return (
-    <div>
-      <h1>
-        {para.first_name} {para.last_name}
-      </h1>
-      <p>
-        <b>Para ID:</b> {para.user_id}
-      </p>
-      <p>
-        <b>Para Email:</b> {para.email}
-      </p>
+    <Stack
+      spacing={2}
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        width: "100%",
+      }}
+    >
+      <Container
+        className={$StaffPage.staffInfoContainer}
+        sx={{ marginBottom: "1rem" }}
+      >
+        <Box className={$StaffPage.displayBox}>
+          <p className={$StaffPage.staffName}>
+            {para?.first_name} {para?.last_name}
+          </p>
 
-      {me?.user_id !== user_id && (
-        <button
-          className={`${$button.default} ${$home.bold}`}
-          onClick={() => setUnassignParaPrompt(true)}
-        >
-          Unassign Para
-        </button>
+          {/* Edit button only to be shown when view state is set to MAIN */}
+          {viewState === VIEW_STATES.MAIN && (
+            <Button
+              className={`${$button.default} ${$home.bold}`}
+              variant="outlined"
+              sx={{
+                color: "#5347d7",
+                borderColor: "#5347d7",
+                borderRadius: "8px",
+                fontFamily: "Quicksand",
+                fontSize: "1em",
+                textTransform: "capitalize",
+              }}
+              onClick={handleEditState}
+            >
+              Edit
+            </Button>
+          )}
+          {/* Save and Cancel buttons only to be shown when view state is set to EDIT */}
+          {viewState === VIEW_STATES.EDIT && (
+            <Box className={$StaffPage.displayBoxGap}>
+              <Button
+                onClick={handleMainState}
+                className={`${$button.default} ${$home.bold}`}
+                variant="outlined"
+                sx={{
+                  color: "#5347d7",
+                  borderColor: "#5347d7",
+                  borderRadius: "8px",
+                  fontFamily: "Quicksand",
+                  textTransform: "capitalize",
+                  fontSize: "1em",
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                className={`${$button.default} ${$home.bold}`}
+                sx={[
+                  {
+                    backgroundColor: "#5347d7",
+                    borderRadius: "8px",
+                    border: "none",
+                    color: "#ffffff",
+                    fontFamily: "Quicksand",
+                    textTransform: "capitalize",
+                    fontSize: "1em",
+                  },
+                  buttonSX,
+                ]}
+                type="submit"
+                form="edit"
+                variant="contained"
+              >
+                Save
+              </Button>
+            </Box>
+          )}
+        </Box>
+
+        {/* if view state is "EDIT" then show the edit version of the student page */}
+        {viewState === VIEW_STATES.EDIT && <h3>Edit Profile</h3>}
+
+        {viewState === VIEW_STATES.MAIN && (
+          <Box className={$StaffPage.displayBox}>
+            <Box gap={10} className={$StaffPage.infoBox}>
+              <div className={$StaffPage.singleInfoArea}>
+                <p>Email</p>
+                <p className={$StaffPage.centerText}>{para?.email}</p>
+              </div>
+              <div className={$StaffPage.singleInfoArea}></div>
+            </Box>
+          </Box>
+        )}
+      </Container>
+
+      {viewState === VIEW_STATES.EDIT && (
+        <Stack gap={0.5} sx={{ width: "100%" }}>
+          <form
+            className={$StaffPage.editForm}
+            id="edit"
+            onSubmit={() => alert("Edit Staff placeholder")}
+          >
+            <Stack gap={0.5}>
+              <Container
+                className={$StaffPage.studentEditContainer}
+                sx={{
+                  display: "grid",
+                  gridTemplateColumns: "200px 30px 300px",
+                }}
+              >
+                <label>First Name</label>
+                <p>:</p>
+                <input
+                  type="text"
+                  name="firstName"
+                  placeholder={para?.first_name || ""}
+                  required
+                />
+              </Container>
+              <Container
+                className={$StaffPage.studentEditContainer}
+                sx={{
+                  display: "grid",
+                  gridTemplateColumns: "200px 30px 300px",
+                }}
+              >
+                <label>Last Name</label>
+                <p>:</p>
+                <input
+                  type="text"
+                  name="lastName"
+                  placeholder={para?.last_name || ""}
+                  required
+                />
+              </Container>
+              <Container
+                className={$StaffPage.studentEditContainer}
+                sx={{
+                  display: "grid",
+                  gridTemplateColumns: "200px 30px 300px",
+                }}
+              >
+                <label>Email</label>
+                <p>:</p>
+                <input
+                  type="text"
+                  name="email"
+                  placeholder={para?.email || ""}
+                  required
+                />
+              </Container>
+            </Stack>
+          </form>
+
+          <Container sx={{ marginTop: "2rem" }}>
+            <Box textAlign="center">
+              <Button
+                onClick={() => setArchiveParaPrompt(true)}
+                className={`${$button.default} ${$home.bold}`}
+                variant="outlined"
+                sx={{
+                  color: "#5347d7",
+                  borderColor: "#5347d7",
+                  borderRadius: "8px",
+                  fontFamily: "Quicksand",
+                  textTransform: "capitalize",
+                  fontSize: "1em",
+                }}
+              >
+                Archive {para?.first_name} {para?.last_name}
+              </Button>
+            </Box>
+          </Container>
+        </Stack>
       )}
 
-      {unassignParaPrompt ? (
-        <div>
-          <p>
-            {`Are you sure you want to unassign ${para.first_name} ${para.last_name}?`}
+      {/* Archiving Staff Modal appears when "Archive" button is pressed*/}
+      <Modal
+        open={archiveParaPrompt}
+        onClose={() => setArchiveParaPrompt(false)}
+        aria-labelledby="archiving-student"
+        aria-describedby="archiving-current-student"
+      >
+        <Box className={$Modal.modalContent}>
+          <p className={$StaffPage.centerText}>
+            Are you sure you want to archive
           </p>
-          <button
-            className={`${$button.default} ${$home.bold}`}
-            onClick={() => handleUnassignPara()}
-          >
-            Yes
-          </button>
-          <button
-            className={`${$button.default} ${$home.bold}`}
-            onClick={() => setUnassignParaPrompt(false)}
-          >
-            No
-          </button>
-        </div>
-      ) : null}
-
-      <Link href={`/staff`}>
-        <p>Return to Staff List</p>
-      </Link>
-    </div>
+          <p className={$StaffPage.centerText}>
+            <b>
+              {para?.first_name} {para?.last_name}
+            </b>
+          </p>
+          <Box className={$StaffPage.archiveOptions}>
+            <button
+              className={`${$button.default} ${$home.bold}`}
+              onClick={() => handleArchivePara()}
+            >
+              Yes
+            </button>
+            <button
+              className={`${$button.default} ${$home.bold}`}
+              onClick={() => setArchiveParaPrompt(false)}
+            >
+              No
+            </button>
+          </Box>
+        </Box>
+      </Modal>
+    </Stack>
   );
 };
 

--- a/src/pages/staff/[user_id].tsx
+++ b/src/pages/staff/[user_id].tsx
@@ -50,14 +50,14 @@ const ViewParaPage = () => {
     onSuccess: () => utils.para.getParaById.invalidate(),
   });
 
-  const handleEditPara = (e: React.ChangeEvent<HTMLFormElement>) => {
+  const handleEditPara = async (e: React.ChangeEvent<HTMLFormElement>) => {
     e.preventDefault();
     const data = new FormData(e.currentTarget);
 
     if (!para) {
       return; // TODO: improve error handling
     }
-    editMutation.mutate({
+    await editMutation.mutateAsync({
       para_id: para.user_id,
       first_name: data.get("firstName") as string,
       last_name: data.get("lastName") as string,
@@ -76,6 +76,7 @@ const ViewParaPage = () => {
 
   const handleArchivePara = async () => {
     if (!para) return;
+    if (para.user_id === me?.user_id) alert("You cannot archive yourself!");
 
     await archivePara.mutateAsync({ para_id: para.user_id });
     await router.push(`/staff`);

--- a/src/pages/staff/[user_id].tsx
+++ b/src/pages/staff/[user_id].tsx
@@ -16,6 +16,7 @@ const ViewParaPage = () => {
   const [archiveParaPrompt, setArchiveParaPrompt] = useState(false);
   const [viewState, setViewState] = useState(0);
 
+  const utils = trpc.useContext();
   const router = useRouter();
   const { user_id } = router.query;
   const { data: me } = trpc.user.getMe.useQuery();
@@ -43,6 +44,26 @@ const ViewParaPage = () => {
     "&:hover": {
       background: "#3023B8",
     },
+  };
+
+  const editMutation = trpc.case_manager.editPara.useMutation({
+    onSuccess: () => utils.para.getParaById.invalidate(),
+  });
+
+  const handleEditPara = (e: React.ChangeEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const data = new FormData(e.currentTarget);
+
+    if (!para) {
+      return; // TODO: improve error handling
+    }
+    editMutation.mutate({
+      para_id: para.user_id,
+      first_name: data.get("firstName") as string,
+      last_name: data.get("lastName") as string,
+      email: data.get("email") as string,
+    });
+    handleMainState();
   };
 
   const archivePara = trpc.case_manager.removePara.useMutation({
@@ -166,11 +187,11 @@ const ViewParaPage = () => {
           <form
             className={$StaffPage.editForm}
             id="edit"
-            onSubmit={() => alert("Edit Staff placeholder")}
+            onSubmit={handleEditPara}
           >
             <Stack gap={0.5}>
               <Container
-                className={$StaffPage.studentEditContainer}
+                className={$StaffPage.staffEditContainer}
                 sx={{
                   display: "grid",
                   gridTemplateColumns: "200px 30px 300px",
@@ -186,7 +207,7 @@ const ViewParaPage = () => {
                 />
               </Container>
               <Container
-                className={$StaffPage.studentEditContainer}
+                className={$StaffPage.staffEditContainer}
                 sx={{
                   display: "grid",
                   gridTemplateColumns: "200px 30px 300px",
@@ -202,7 +223,7 @@ const ViewParaPage = () => {
                 />
               </Container>
               <Container
-                className={$StaffPage.studentEditContainer}
+                className={$StaffPage.staffEditContainer}
                 sx={{
                   display: "grid",
                   gridTemplateColumns: "200px 30px 300px",

--- a/src/styles/StaffPage.module.css
+++ b/src/styles/StaffPage.module.css
@@ -14,6 +14,7 @@
   display: flex;
   justify-content: space-between;
   padding: 10px 0;
+  margin-left: 0.5rem;
 }
 
 .displayBoxGap {

--- a/src/styles/StaffPage.module.css
+++ b/src/styles/StaffPage.module.css
@@ -1,0 +1,76 @@
+.staffInfoContainer {
+  background-color: #ffffff;
+  border-radius: 10px;
+  padding: 0.5rem;
+}
+
+.staffEditContainer {
+  background-color: #ffffff;
+  border-radius: 10px;
+  padding: 20px 50px;
+}
+
+.displayBox {
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 0;
+}
+
+.displayBoxGap {
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 0;
+  gap: 1rem;
+}
+
+.staffName {
+  font-size: xx-large;
+}
+
+.infoBox {
+  display: flex;
+}
+
+.editForm {
+  width: 100%;
+}
+
+.singleInfoArea {
+  padding: 10px 0;
+  text-align: center;
+}
+
+.centerText {
+  text-align: center;
+  padding-top: 10px;
+}
+
+.noStaffContainer {
+  background-color: #ffffff;
+  border-radius: 10px;
+  margin-top: 2rem;
+  min-height: 50vh;
+  max-height: 70vh;
+}
+
+.noStaffBox {
+  padding-top: 1rem;
+  padding-bottom: 4rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.textSpacing {
+  margin-bottom: 1rem;
+}
+
+.textLarge {
+  font-size: large;
+}
+
+.archiveOptions {
+  display: flex;
+  justify-content: space-evenly;
+  padding-top: 2rem;
+}

--- a/src/styles/StudentPage.module.css
+++ b/src/styles/StudentPage.module.css
@@ -14,6 +14,7 @@
   display: flex;
   justify-content: space-between;
   padding: 10px 0;
+  margin-left: 0.5rem;
 }
 
 .displayBoxGap {


### PR DESCRIPTION
Staff page: ticket #200 
- Build staff page, emulating student page.
- In user_id.tsx, add edit/view states with Save and Cancel buttons, display email address, add form with inputs/placeholders, refactor Archive button to match Student archive, add Modal to open when Archive button pressed.
- Create StaffPage.module.css file.
- Add editPara authenticated procedure in case_manager.ts so that case_manager can edit para name and email.
- Add mainStaff to Layout.module.css to have same bg color as student page.
- Update Layout.tsx to include logic to check if user_id for bg color.
- Add handleEditPara function and editMutation to user_id.tsx.
- Add logic to editPara to determine if userId is same as para_id to prevent para from editing another para while letting them edit themself.