### PR TITLE
Fix error - create trial twice & task card % logic

### DIFF
--- a/src/components/taskCard/taskCard.tsx
+++ b/src/components/taskCard/taskCard.tsx
@@ -28,9 +28,11 @@ interface TaskCardProps {
 const TaskCard = ({ task }: TaskCardProps) => {
   const completionRate = useMemo(() => {
     const num = parseInt(task.completed_trials as string) || 0;
-    const calculatedRate = Math.floor((num / (task.trial_count ?? 1)) * 100);
+    const calculatedRate = Math.floor(
+      (num / (task.target_max_attempts ?? 1)) * 100
+    );
     return calculatedRate;
-  }, [task.completed_trials, task.trial_count]);
+  }, [task.completed_trials, task.target_max_attempts]);
 
   const getDateStyle = () => {
     //New or done should be green
@@ -56,7 +58,9 @@ const TaskCard = ({ task }: TaskCardProps) => {
           ? "NEW"
           : completionRate >= 100
           ? "DONE"
-          : `DUE: ${task.due_date ? format(task.due_date, "MM-dd-yyyy") : ""}`}
+          : `DUE: ${
+              task.due_date ? format(task.due_date, "MM-dd-yyyy") : "N/A"
+            }`}
       </div>
       <div className={$taskCard.profile}>
         {/* <Image src={task.profile_img} height={50} width={50} alt="Student's profile picture."/> */}

--- a/src/pages/benchmarks/[benchmark_id]/index.tsx
+++ b/src/pages/benchmarks/[benchmark_id]/index.tsx
@@ -68,6 +68,8 @@ const BenchmarkPage = () => {
   const [currentTrialIdx, setCurrentTrialIdx] = useState(0);
   const currentTrial = task?.trials[currentTrialIdx] || null;
 
+  const [trialAdded, setTrialAdded] = useState(false);
+
   const hasInputChanged =
     currentTrial?.notes !== notesInputValue ||
     currentTrial?.success !== successInputValue ||
@@ -103,6 +105,7 @@ const BenchmarkPage = () => {
   // Creates a new data collection instance (if there are none in progress)
   useEffect(() => {
     if (
+      !trialAdded &&
       !addTrialMutation.isLoading &&
       !taskIsLoading &&
       task &&
@@ -115,8 +118,9 @@ const BenchmarkPage = () => {
         unsuccess: 0,
         notes: "",
       });
+      setTrialAdded(true);
     }
-  }, [task, addTrialMutation, taskIsLoading]);
+  }, [task, addTrialMutation, taskIsLoading, trialAdded]);
 
   const handleUpdate = (updates: DataUpdate) => {
     //Can only update if we're on the most recent trial


### PR DESCRIPTION
#249

- Added new state `TrialAdded` to ensure the trial is only added once.
- Fix logic for task cards having 100% after each submission.

![Screenshot 2024-02-16 at 10 10 04 AM](https://github.com/sfbrigade/compass/assets/104481165/b6a20a78-026e-49db-9aea-9fe96f2a9694)