### PR TITLE
Add scalable font size to global and adjust font size of other files.

### DIFF
--- a/src/components/design_system/button/Button.module.css
+++ b/src/components/design_system/button/Button.module.css
@@ -8,7 +8,7 @@
   cursor: pointer;
   text-decoration: none;
   text-align: center;
-  font-size: 16px;
+  font-size: var(--base-size);
   text-transform: none;
   line-height: normal;
   letter-spacing: 0;
@@ -44,7 +44,7 @@
   cursor: pointer;
   text-decoration: none;
   text-align: center;
-  font-size: 16px;
+  font-size: var(--base-size);
   background-color: inherit;
   font-family: var(--quicksand);
   text-transform: none;

--- a/src/components/table/Table.module.css
+++ b/src/components/table/Table.module.css
@@ -1,5 +1,4 @@
 .tableTitle {
-  font-size: 30px;
   font-weight: 600;
 }
 
@@ -9,7 +8,7 @@
 }
 
 .headerLabel {
-  font-size: 17px;
+  font-size: var(--h5);
   color: var(--grey-20);
 }
 

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -102,7 +102,7 @@ function EnhancedTableHead<Column extends HeadCell>({
               active={orderBy === headCell.id}
               direction={orderBy === headCell.id ? order : "asc"}
               onClick={createSortHandler(headCell.id)}
-              className={$table.headerLabel}
+              className={`${$table.headerLabel}`}
             >
               {headCell.label}
               {orderBy === headCell.id ? (
@@ -152,8 +152,8 @@ function EnhancedTableToolbar({
               width: "100%",
             }}
           >
-            <h2 className={$table.tableTitle}>{type}</h2>
-            <button onClick={onOpenInput} className={$button.default}>
+            <h3 className={$table.tableTitle}>{type}</h3>
+            <button onClick={onOpenInput} className={`${$button.default}`}>
               Add {type}
             </button>
           </div>

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -6,23 +6,6 @@ const Settings = () => {
   return (
     <div>
       <p>🚧 Under Construction! 🚧</p>
-      <h1 style={{ border: "1px solid black" }}>h1 This is h1 Element</h1>
-      <h2 style={{ border: "1px solid black" }}>h2 This is h2 Element</h2>
-      <h3 style={{ border: "1px solid black" }}>h3 This is h3 Element</h3>
-      <h4 style={{ border: "1px solid black" }}>h4 This is h4 Element</h4>
-      <h5 style={{ border: "1px solid black" }}>h5 This is h5 Element</h5>
-      <h6 style={{ border: "1px solid black" }}>h6 This is h6 Element</h6>
-      <p style={{ border: "1px solid black" }}>This is a p Element</p>
-      <p className="body2" style={{ border: "1px solid black" }}>
-        This is a body2 Element
-      </p>
-      <p className="caption" style={{ border: "1px solid black" }}>
-        This is a caption Element
-      </p>
-      <p className="overline" style={{ border: "1px solid black" }}>
-        This is an overline Element
-      </p>
-      <span style={{ border: "1px solid black" }}>This is a Span Element</span>
     </div>
   );
 };

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -6,6 +6,23 @@ const Settings = () => {
   return (
     <div>
       <p>🚧 Under Construction! 🚧</p>
+      <h1 style={{ border: "1px solid black" }}>h1 This is h1 Element</h1>
+      <h2 style={{ border: "1px solid black" }}>h2 This is h2 Element</h2>
+      <h3 style={{ border: "1px solid black" }}>h3 This is h3 Element</h3>
+      <h4 style={{ border: "1px solid black" }}>h4 This is h4 Element</h4>
+      <h5 style={{ border: "1px solid black" }}>h5 This is h5 Element</h5>
+      <h6 style={{ border: "1px solid black" }}>h6 This is h6 Element</h6>
+      <p style={{ border: "1px solid black" }}>This is a p Element</p>
+      <p className="body2" style={{ border: "1px solid black" }}>
+        This is a body2 Element
+      </p>
+      <p className="caption" style={{ border: "1px solid black" }}>
+        This is a caption Element
+      </p>
+      <p className="overline" style={{ border: "1px solid black" }}>
+        This is an overline Element
+      </p>
+      <span style={{ border: "1px solid black" }}>This is a Span Element</span>
     </div>
   );
 };

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -138,7 +138,7 @@ p {
 /* Small Devices, Phones & Tablet [long screen] */
 @media only screen and (min-width: 480px) {
   :root {
-    --base-size: .925rem;
+    --base-size: .9375rem;
   }
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -49,7 +49,7 @@
   --grey-100: #ffffff;
 
   /* Easy Text Size Scaling */
-  --base-size: .875rem; /* equivalent to 14px */
+  --base-size: 0.875rem; /* 14px */
   --scale: 1.25;
   --h1: calc(var(--h2) * var(--scale));
   --h2: calc(var(--h3) * var(--scale));
@@ -65,7 +65,9 @@ html {
   box-sizing: border-box;
 }
 
-*, *:before, *:after {
+*,
+*:before,
+*:after {
   box-sizing: inherit;
   padding: 0;
   margin: 0;
@@ -96,27 +98,33 @@ textarea {
 }
 
 /* Scalable H elements with h classes that can be a substitute for H elements */
-h1, .h1 {
+h1,
+.h1 {
   font-size: var(--h1);
 }
 
-h2, .h2 {
+h2,
+.h2 {
   font-size: var(--h2);
 }
 
-h3, .h3 {
+h3,
+.h3 {
   font-size: var(--h3);
 }
 
-h4, .h4 {
+h4,
+.h4 {
   font-size: var(--h4);
 }
 
-h5, .h5 {
+h5,
+.h5 {
   font-size: var(--h5);
 }
 
-h6, .h6 {
+h6,
+.h6 {
   font-size: var(--h6);
 }
 
@@ -138,7 +146,7 @@ p {
 /* Small Devices, Phones & Tablet [long screen] */
 @media only screen and (min-width: 480px) {
   :root {
-    --base-size: .9375rem;
+    --base-size: 0.9375rem; /* 15px */
   }
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -53,7 +53,6 @@
   /* Easy Text Size Scaling */
   --base-size: 0.875rem; /* 14px */
   --scale: 1.2;
-  --h0: 2.488rem;
   --h1: calc(var(--h2) * var(--scale));
   --h2: calc(var(--h3) * var(--scale));
   --h3: calc(var(--h4) * var(--scale));
@@ -109,11 +108,17 @@ textarea {
 
 /* Scalable H elements with h classes that can be a substitute for H elements */
 h1,
+.h1,
 h2,
+.h2,
 h3,
+.h3,
 h4,
+.h4,
 h5,
-h6 {
+.h5,
+h6,
+.h6 {
   font-weight: 600;
   font-family: Quicksand;
   line-height: 1.5;
@@ -157,11 +162,8 @@ h6,
   font-size: var(--xs);
 }
 
-p {
-  font-size: var(--base-size);
-}
-
 p,
+.body1,
 .body2,
 .caption,
 .overline,
@@ -171,10 +173,21 @@ span {
   font-weight: var(--regular);
 }
 
+p {
+  font-size: var(--base-size);
+}
+
+/* Text or similar style */
+.body1 {
+  font-size: var(--base-size);
+}
+
+/* Usage - description for filling out forms */
 .body2 {
   font-size: var(--sm);
 }
 
+/* For Images */
 .caption {
   font-size: var(--xs);
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -49,7 +49,7 @@
   --grey-100: #ffffff;
 
   /* Easy Text Size Scaling */
-  --base-size: .875rem;
+  --base-size: .875rem; /* equivalent to 14px */
   --scale: 1.25;
   --h1: calc(var(--h2) * var(--scale));
   --h2: calc(var(--h3) * var(--scale));
@@ -58,6 +58,7 @@
   --h5: calc(var(--h6) * var(--scale));
   --h6: var(--base-size);
   --sm: calc(var(--h6) / var(--scale));
+  --xs: calc(var(--sm) / var(--scale));
 }
 
 html {
@@ -123,6 +124,10 @@ h6, .h6 {
   font-size: var(--sm);
 }
 
+.xs {
+  font-size: var(--xs);
+}
+
 p {
   font-size: var(--base-size);
 }
@@ -155,7 +160,4 @@ p {
 
 /* Large Devices, Wide Screens */
 @media only screen and (min-width: 1200px) {
-  :root {
-    --base-size: 1.125rem;
-  }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,5 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Quicksand:wght@300..700&display=swap");
+
 :root {
   --primary: #20159e;
   --on-primary: #ffffff;
@@ -50,7 +52,8 @@
 
   /* Easy Text Size Scaling */
   --base-size: 0.875rem; /* 14px */
-  --scale: 1.25;
+  --scale: 1.2;
+  --h0: 2.488rem;
   --h1: calc(var(--h2) * var(--scale));
   --h2: calc(var(--h3) * var(--scale));
   --h3: calc(var(--h4) * var(--scale));
@@ -59,6 +62,13 @@
   --h6: var(--base-size);
   --sm: calc(var(--h6) / var(--scale));
   --xs: calc(var(--sm) / var(--scale));
+
+  /* Fonts */
+  --quicksand: Quicksand;
+  --inter: Inter;
+  --regular: 300;
+  --semibold: 600;
+  --bold: 700;
 }
 
 html {
@@ -98,6 +108,17 @@ textarea {
 }
 
 /* Scalable H elements with h classes that can be a substitute for H elements */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: 600;
+  font-family: Quicksand;
+  line-height: 1.5;
+}
+
 h1,
 .h1 {
   font-size: var(--h1);
@@ -140,32 +161,52 @@ p {
   font-size: var(--base-size);
 }
 
+p,
+.body2,
+.caption,
+.overline,
+span {
+  line-height: 1.5;
+  font-family: Inter;
+  font-weight: var(--regular);
+}
+
+.body2 {
+  font-size: var(--sm);
+}
+
+.caption {
+  font-size: var(--xs);
+}
+
+.overline {
+  font-size: var(--xs);
+  font-weight: var(--semibold);
+  text-transform: uppercase;
+}
+
 /* Breakpoints recommended by Bootstrap */
 /* Screens smaller than [480px] uses css above */
 
-/* Small Devices, Phones & Tablet [long screen] */
+/* Phones [wide screen] - Tablet [long screen] */
 @media only screen and (min-width: 480px) {
   :root {
     --base-size: 0.9375rem; /* 15px */
   }
 }
 
-/* Small Devices, Tablets [wide screen]*/
+/* Tablets [wide screen]*/
 @media only screen and (min-width: 768px) {
   :root {
     --base-size: 1rem;
   }
 }
 
-/* Medium Devices, Desktops */
+/* Desktops */
 @media only screen and (min-width: 992px) {
   html,
   body,
   #__next {
     padding-top: 0;
   }
-}
-
-/* Large Devices, Wide Screens */
-@media only screen and (min-width: 1200px) {
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -47,10 +47,25 @@
   --grey-80: #f4f6f7;
   --grey-90: #f6f8f9;
   --grey-100: #ffffff;
+
+  /* Easy Text Size Scaling */
+  --base-size: .875rem;
+  --scale: 1.25;
+  --h1: calc(var(--h2) * var(--scale));
+  --h2: calc(var(--h3) * var(--scale));
+  --h3: calc(var(--h4) * var(--scale));
+  --h4: calc(var(--h5) * var(--scale));
+  --h5: calc(var(--h6) * var(--scale));
+  --h6: var(--base-size);
+  --sm: calc(var(--h6) / var(--scale));
 }
 
-* {
+html {
   box-sizing: border-box;
+}
+
+*, *:before, *:after {
+  box-sizing: inherit;
   padding: 0;
   margin: 0;
 }
@@ -61,6 +76,7 @@ body,
   height: 100%;
   overflow-x: auto;
   padding-top: 0.5rem;
+  font-size: var(--base-size);
 }
 
 strong {
@@ -78,17 +94,54 @@ textarea {
   outline: none;
 }
 
+/* Scalable H elements with h classes that can be a substitute for H elements */
+h1, .h1 {
+  font-size: var(--h1);
+}
+
+h2, .h2 {
+  font-size: var(--h2);
+}
+
+h3, .h3 {
+  font-size: var(--h3);
+}
+
+h4, .h4 {
+  font-size: var(--h4);
+}
+
+h5, .h5 {
+  font-size: var(--h5);
+}
+
+h6, .h6 {
+  font-size: var(--h6);
+}
+
+.sm {
+  font-size: var(--sm);
+}
+
+p {
+  font-size: var(--base-size);
+}
+
 /* Breakpoints recommended by Bootstrap */
-/* Custom, iPhone Retina */
-@media only screen and (min-width: 320px) {
-}
+/* Screens smaller than [480px] uses css above */
 
-/* Extra Small Devices, Phones */
+/* Small Devices, Phones & Tablet [long screen] */
 @media only screen and (min-width: 480px) {
+  :root {
+    --base-size: .925rem;
+  }
 }
 
-/* Small Devices, Tablets */
+/* Small Devices, Tablets [wide screen]*/
 @media only screen and (min-width: 768px) {
+  :root {
+    --base-size: 1rem;
+  }
 }
 
 /* Medium Devices, Desktops */
@@ -102,4 +155,7 @@ textarea {
 
 /* Large Devices, Wide Screens */
 @media only screen and (min-width: 1200px) {
+  :root {
+    --base-size: 1.125rem;
+  }
 }


### PR DESCRIPTION
#293

Font size at .875rem [14px] at screens lower than 480px.
Font size at .9375rem [15px] at screens above 480px.
Font size at 1rem [16px] at screens above 768px.
Add reusable font-size classes including small and x-small sizes.

Following [Typography chart ](https://www.figma.com/file/m09znscRXNqSziAiEbNLTf/Compass-Designs?type=design&node-id=12388-48833&mode=design&t=ghaGyca0JE0N57m0-4)
![Typography](https://github.com/sfbrigade/compass/assets/104481165/80c7d8b5-40df-4a72-8d1a-d9f86f916c1a)
