### PR TITLE
Add Nav tab for benchmarks

### DIFF
--- a/src/components/design_system/button/Button.module.css
+++ b/src/components/design_system/button/Button.module.css
@@ -69,6 +69,7 @@
 .pilled {
   border-radius: 20px;
   padding: 5px 10px;
+  background-color: var(--primary-90);
 }
 
 .circular {

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -22,8 +22,9 @@ const Layout = ({ children }: LayoutProps) => {
       <main
         className={`${isPurpleBg ? $layout.mainPurple : $layout.main}
         ${router.query.student_id ? $layout.mainStudent : ""}
-        ${router.query.goal_id ? $layout.mainGoal : ""} 
-        ${router.query.user_id ? $layout.mainStaff : ""}`}
+        ${router.query.goal_id ? $layout.mainGoal : ""}
+        ${router.query.user_id ? $layout.mainStaff : ""}
+        ${router.pathname.includes("benchmarks") ? $layout.mainPurple : ""}`}
       >
         {children}
       </main>

--- a/src/components/navbar/NavBar.tsx
+++ b/src/components/navbar/NavBar.tsx
@@ -1,9 +1,10 @@
 import CloseIcon from "@mui/icons-material/Close";
-import CoPresent from "@mui/icons-material/CoPresent";
+import PeopleOutline from "@mui/icons-material/PeopleOutline";
 import Logout from "@mui/icons-material/Logout";
 import MenuIcon from "@mui/icons-material/Menu";
-import PeopleOutline from "@mui/icons-material/PeopleOutline";
-import Settings from "@mui/icons-material/Settings";
+import SchoolOutlined from "@mui/icons-material/SchoolOutlined";
+import ContentPaste from "@mui/icons-material/ContentPaste";
+import SettingsOutlined from "@mui/icons-material/SettingsOutlined";
 import AppBar from "@mui/material/AppBar";
 import Box from "@mui/material/Box";
 import Drawer from "@mui/material/Drawer";
@@ -90,9 +91,10 @@ export default function NavBar() {
   const drawer = (
     <div className={$navbar.navbarDropdown}>
       <List>
-        <NavItem href="/students" icon={<PeopleOutline />} text="Students" />
-        <NavItem href="/staff" icon={<CoPresent />} text="Staff" />
-        <NavItem href="/settings" icon={<Settings />} text="Settings" />
+        <NavItem href="/benchmarks" icon={<ContentPaste />} text="Assigned" />
+        <NavItem href="/students" icon={<SchoolOutlined />} text="Students" />
+        <NavItem href="/staff" icon={<PeopleOutline />} text="Staff" />
+        <NavItem href="/settings" icon={<SettingsOutlined />} text="Settings" />
         <NavItem
           icon={<Logout />}
           text="Logout"

--- a/src/components/taskCard/TaskCard.module.css
+++ b/src/components/taskCard/TaskCard.module.css
@@ -48,7 +48,8 @@
   color: var(--grey-30);
   display: flex;
   flex-direction: column;
+  justify-content: flex-end;
   align-items: flex-end;
   gap: 3px;
-  margin: 10px 0;
+  width: 65%;
 }

--- a/src/components/taskCard/taskCard.tsx
+++ b/src/components/taskCard/taskCard.tsx
@@ -1,10 +1,10 @@
-import React, { useMemo } from "react";
-import $taskCard from "./TaskCard.module.css";
 import $button from "@/components/design_system/button/Button.module.css";
 import $box from "@/styles/Box.module.css";
-import Link from "next/link";
-import ProgressBar from "../progressBar/progressBar";
 import { differenceInWeeks, format } from "date-fns";
+import Link from "next/link";
+import { useMemo } from "react";
+import ProgressBar from "../progressBar/progressBar";
+import $taskCard from "./TaskCard.module.css";
 
 interface ParaTaskCard {
   task_id: string;
@@ -22,9 +22,10 @@ interface ParaTaskCard {
 
 interface TaskCardProps {
   task: ParaTaskCard;
+  isPara: boolean;
 }
 
-const TaskCard = ({ task }: TaskCardProps) => {
+const TaskCard = ({ task, isPara }: TaskCardProps) => {
   const completionRate = useMemo(() => {
     const num = parseInt(task.completed_trials as string) || 0;
     const calculatedRate = Math.floor(
@@ -49,8 +50,6 @@ const TaskCard = ({ task }: TaskCardProps) => {
       return $taskCard.dateFloater;
     }
   };
-
-  console.log("task ", task);
 
   return (
     <div className={completionRate >= 100 ? $box.inactive : $box.greyBg}>
@@ -79,12 +78,15 @@ const TaskCard = ({ task }: TaskCardProps) => {
         </div>
 
         <div style={{ display: "flex", gap: "1rem" }}>
-          <Link
-            href={`/benchmarks/${task.task_id}`}
-            className={`${$button.secondary}`}
-          >
-            View benchmark
-          </Link>
+          {/* Para smaller screen view may click on card instead */}
+          {!isPara ? (
+            <Link
+              href={`/benchmarks/${task.task_id}`}
+              className={`${$button.secondary}`}
+            >
+              View benchmark
+            </Link>
+          ) : null}
 
           <Link
             href={`/benchmarks/${task.task_id}`}

--- a/src/components/taskCard/taskCard.tsx
+++ b/src/components/taskCard/taskCard.tsx
@@ -67,7 +67,7 @@ const TaskCard = ({ task, isPara }: TaskCardProps) => {
 
       <div style={{ display: "flex", justifyContent: "space-between" }}>
         <p>
-          <strong>{task.category}</strong> - {task.description}
+          <strong>{task?.category}</strong> - {task?.description}
         </p>
 
         <div style={{ display: "flex", gap: "1rem" }}>

--- a/src/components/taskCard/taskCard.tsx
+++ b/src/components/taskCard/taskCard.tsx
@@ -71,7 +71,7 @@ const TaskCard = ({ task, isPara }: TaskCardProps) => {
         </p>
 
         <div style={{ display: "flex", gap: "1rem" }}>
-          {/* Para smaller screen view may click on card instead */}
+          {/* Para smaller screen view can click on card instead */}
           {!isPara ? (
             <Link
               href={`/benchmarks/${task.task_id}`}

--- a/src/components/taskCard/taskCard.tsx
+++ b/src/components/taskCard/taskCard.tsx
@@ -3,7 +3,6 @@ import $box from "@/styles/Box.module.css";
 import { differenceInWeeks, format } from "date-fns";
 import Link from "next/link";
 import { useMemo } from "react";
-import ProgressBar from "../progressBar/progressBar";
 import $taskCard from "./TaskCard.module.css";
 
 interface ParaTaskCard {
@@ -65,17 +64,11 @@ const TaskCard = ({ task, isPara }: TaskCardProps) => {
       <div className={$taskCard.profile}>
         {task.first_name} {task.last_name}
       </div>
-      <div>
+
+      <div style={{ display: "flex", justifyContent: "space-between" }}>
         <p>
           <strong>{task.category}</strong> - {task.description}
         </p>
-      </div>
-
-      <div style={{ display: "flex", justifyContent: "space-between" }}>
-        <div className={$taskCard.progressBar}>
-          {completionRate}% complete
-          <ProgressBar fillPercent={completionRate} />
-        </div>
 
         <div style={{ display: "flex", gap: "1rem" }}>
           {/* Para smaller screen view may click on card instead */}

--- a/src/components/taskCard/taskCard.tsx
+++ b/src/components/taskCard/taskCard.tsx
@@ -1,4 +1,3 @@
-// import Image from "next/image";
 import React, { useMemo } from "react";
 import $taskCard from "./TaskCard.module.css";
 import $button from "@/components/design_system/button/Button.module.css";
@@ -51,6 +50,8 @@ const TaskCard = ({ task }: TaskCardProps) => {
     }
   };
 
+  console.log("task ", task);
+
   return (
     <div className={completionRate >= 100 ? $box.inactive : $box.greyBg}>
       <div className={getDateStyle()}>
@@ -63,15 +64,7 @@ const TaskCard = ({ task }: TaskCardProps) => {
             }`}
       </div>
       <div className={$taskCard.profile}>
-        {/* <Image src={task.profile_img} height={50} width={50} alt="Student's profile picture."/> */}
-        <div
-          className={
-            completionRate >= 100 ? $taskCard.imageDone : $taskCard.image
-          }
-        ></div>
-        <div>
-          {task.first_name} {task.last_name}
-        </div>
+        {task.first_name} {task.last_name}
       </div>
       <div>
         <p>
@@ -79,19 +72,30 @@ const TaskCard = ({ task }: TaskCardProps) => {
         </p>
       </div>
 
-      <div className={$taskCard.progressBar}>
-        {completionRate}% complete
-        <ProgressBar fillPercent={completionRate} />
-      </div>
+      <div style={{ display: "flex", justifyContent: "space-between" }}>
+        <div className={$taskCard.progressBar}>
+          {completionRate}% complete
+          <ProgressBar fillPercent={completionRate} />
+        </div>
 
-      <Link
-        href={`/benchmarks/${task.task_id}`}
-        className={`${$button.default} ${
-          completionRate >= 100 ? $button.inactive : ""
-        }`}
-      >
-        Collect data
-      </Link>
+        <div style={{ display: "flex", gap: "1rem" }}>
+          <Link
+            href={`/benchmarks/${task.task_id}`}
+            className={`${$button.secondary}`}
+          >
+            View benchmark
+          </Link>
+
+          <Link
+            href={`/benchmarks/${task.task_id}`}
+            className={`${$button.default} ${
+              completionRate >= 100 ? $button.inactive : ""
+            }`}
+          >
+            Collect data
+          </Link>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/pages/benchmarks/index.tsx
+++ b/src/pages/benchmarks/index.tsx
@@ -1,10 +1,15 @@
-import React from "react";
-import TaskCard from "@/components/taskCard/taskCard";
 import { trpc } from "@/client/lib/trpc";
+import TaskCard from "@/components/taskCard/taskCard";
 import $typo from "@/styles/Typography.module.css";
-import { Container, Box } from "@mui/material";
+import { Box, Container } from "@mui/material";
 import Image from "next/image";
 import noBenchmarks from "../../public/img/no-benchmarks.png";
+import $box from "../../styles/Box.module.css";
+import $button from "../../components/design_system/button/Button.module.css";
+import Sort from "@mui/icons-material/Sort";
+import FilterAlt from "@mui/icons-material/FilterAlt";
+import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";
+import CheckBoxOutlineBlankOutlinedIcon from "@mui/icons-material/CheckBoxOutlineBlankOutlined";
 
 function Benchmarks() {
   const { data: tasks, isLoading } = trpc.para.getMyTasks.useQuery();
@@ -33,15 +38,58 @@ function Benchmarks() {
           </Box>
         </Container>
       ) : (
-        <ul>
+        <Container sx={{ marginTop: "2rem" }}>
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+            }}
+          >
+            <h3>Assigned Students</h3>
+            <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
+              <span
+                style={{
+                  display: "flex",
+                  maxWidth: "fit-content",
+                  alignItems: "center",
+                  gap: "4px",
+                }}
+              >
+                <CheckBoxOutlineBlankOutlinedIcon /> Show all benchmarks
+              </span>
+              <span
+                className={`${$button.pilled}`}
+                style={{
+                  display: "flex",
+                  maxWidth: "fit-content",
+                  alignItems: "center",
+                  gap: "4px",
+                }}
+              >
+                <FilterAlt /> Filter <KeyboardArrowDown />
+              </span>
+              <span
+                className={`${$button.pilled}`}
+                style={{
+                  display: "flex",
+                  maxWidth: "fit-content",
+                  alignItems: "center",
+                  gap: "4px",
+                }}
+              >
+                <Sort /> Sort <KeyboardArrowDown />
+              </span>
+            </div>
+          </Box>
           {tasks?.map((task) => {
             return (
-              <li key={task.task_id} className={$typo.noDecoration}>
+              <div key={task.task_id} className={$typo.noDecoration}>
                 <TaskCard task={task} />
-              </li>
+              </div>
             );
           })}
-        </ul>
+        </Container>
       )}
     </>
   );

--- a/src/pages/benchmarks/index.tsx
+++ b/src/pages/benchmarks/index.tsx
@@ -1,7 +1,6 @@
 import { trpc } from "@/client/lib/trpc";
 import TaskCard from "@/components/taskCard/taskCard";
 import $typo from "@/styles/Typography.module.css";
-import CheckBoxOutlineBlankOutlinedIcon from "@mui/icons-material/CheckBoxOutlineBlankOutlined";
 import FilterAlt from "@mui/icons-material/FilterAlt";
 import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";
 import Sort from "@mui/icons-material/Sort";
@@ -11,6 +10,7 @@ import Link from "next/link";
 import { useState } from "react";
 import $button from "../../components/design_system/button/Button.module.css";
 import noBenchmarks from "../../public/img/no-benchmarks.png";
+import SearchIcon from "@mui/icons-material/Search";
 
 function Benchmarks() {
   const [isPara, setIsPara] = useState(false);
@@ -54,22 +54,30 @@ function Benchmarks() {
           >
             <h3>Assigned Students</h3>
             <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
-              <span>View - {isPara ? "Para" : "Case Manager"}</span>
-              <button onClick={() => handleTogglePara()}>Toggle View</button>
+              {/* Temporary Toggle View of CM and Para */}
+              <span>{isPara ? "Para" : "Case Manager"}</span>
+              <button
+                onClick={() => handleTogglePara()}
+                style={{ padding: "0 4px" }}
+              >
+                Toggle View
+              </button>
 
-              {/* May not be applicable to Para */}
-              {!isPara ? (
-                <span
-                  style={{
-                    display: "flex",
-                    maxWidth: "fit-content",
-                    alignItems: "center",
-                    gap: "4px",
-                  }}
-                >
-                  <CheckBoxOutlineBlankOutlinedIcon /> Show all benchmarks
-                </span>
-              ) : null}
+              {/* Search Pill Placeholder */}
+              <span
+                className={`${$button.secondary}`}
+                style={{
+                  display: "flex",
+                  maxWidth: "fit-content",
+                  alignItems: "center",
+                  borderRadius: "30px",
+                  padding: "4px 20px",
+                }}
+              >
+                <SearchIcon /> Search
+              </span>
+
+              {/* Filter Pill Placeholder */}
               <span
                 className={`${$button.pilled}`}
                 style={{
@@ -81,6 +89,8 @@ function Benchmarks() {
               >
                 <FilterAlt /> Filter <KeyboardArrowDown />
               </span>
+
+              {/* Sort Pill Placeholder*/}
               <span
                 className={`${$button.pilled}`}
                 style={{
@@ -97,9 +107,13 @@ function Benchmarks() {
 
           <Box sx={{ height: "75vh", overflowY: "scroll" }}>
             {tasks?.map((task) => {
+              const completed = Math.floor(
+                Number(task.completed_trials) / Number(task.target_max_attempts)
+              );
               return (
                 <div key={task.task_id} className={$typo.noDecoration}>
-                  {isPara ? (
+                  {/* Temporary CM & Para View */}
+                  {isPara && !completed ? (
                     <Link
                       href={`/benchmarks/${task.task_id}`}
                       style={{ color: "black", textDecoration: "none" }}

--- a/src/pages/benchmarks/index.tsx
+++ b/src/pages/benchmarks/index.tsx
@@ -4,7 +4,6 @@ import $typo from "@/styles/Typography.module.css";
 import { Box, Container } from "@mui/material";
 import Image from "next/image";
 import noBenchmarks from "../../public/img/no-benchmarks.png";
-import $box from "../../styles/Box.module.css";
 import $button from "../../components/design_system/button/Button.module.css";
 import Sort from "@mui/icons-material/Sort";
 import FilterAlt from "@mui/icons-material/FilterAlt";
@@ -82,13 +81,16 @@ function Benchmarks() {
               </span>
             </div>
           </Box>
-          {tasks?.map((task) => {
-            return (
-              <div key={task.task_id} className={$typo.noDecoration}>
-                <TaskCard task={task} />
-              </div>
-            );
-          })}
+
+          <Box sx={{ height: "75vh", overflowY: "scroll" }}>
+            {tasks?.map((task) => {
+              return (
+                <div key={task.task_id} className={$typo.noDecoration}>
+                  <TaskCard task={task} />
+                </div>
+              );
+            })}
+          </Box>
         </Container>
       )}
     </>

--- a/src/pages/benchmarks/index.tsx
+++ b/src/pages/benchmarks/index.tsx
@@ -1,17 +1,24 @@
 import { trpc } from "@/client/lib/trpc";
 import TaskCard from "@/components/taskCard/taskCard";
 import $typo from "@/styles/Typography.module.css";
-import { Box, Container } from "@mui/material";
-import Image from "next/image";
-import noBenchmarks from "../../public/img/no-benchmarks.png";
-import $button from "../../components/design_system/button/Button.module.css";
-import Sort from "@mui/icons-material/Sort";
+import CheckBoxOutlineBlankOutlinedIcon from "@mui/icons-material/CheckBoxOutlineBlankOutlined";
 import FilterAlt from "@mui/icons-material/FilterAlt";
 import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";
-import CheckBoxOutlineBlankOutlinedIcon from "@mui/icons-material/CheckBoxOutlineBlankOutlined";
+import Sort from "@mui/icons-material/Sort";
+import { Box, Container } from "@mui/material";
+import Image from "next/image";
+import Link from "next/link";
+import { useState } from "react";
+import $button from "../../components/design_system/button/Button.module.css";
+import noBenchmarks from "../../public/img/no-benchmarks.png";
 
 function Benchmarks() {
+  const [isPara, setIsPara] = useState(false);
   const { data: tasks, isLoading } = trpc.para.getMyTasks.useQuery();
+
+  const handleTogglePara = () => {
+    setIsPara(!isPara);
+  };
 
   if (isLoading) {
     return <div>Loading...</div>;
@@ -47,16 +54,22 @@ function Benchmarks() {
           >
             <h3>Assigned Students</h3>
             <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
-              <span
-                style={{
-                  display: "flex",
-                  maxWidth: "fit-content",
-                  alignItems: "center",
-                  gap: "4px",
-                }}
-              >
-                <CheckBoxOutlineBlankOutlinedIcon /> Show all benchmarks
-              </span>
+              <span>View - {isPara ? "Para" : "Case Manager"}</span>
+              <button onClick={() => handleTogglePara()}>Toggle View</button>
+
+              {/* May not be applicable to Para */}
+              {!isPara ? (
+                <span
+                  style={{
+                    display: "flex",
+                    maxWidth: "fit-content",
+                    alignItems: "center",
+                    gap: "4px",
+                  }}
+                >
+                  <CheckBoxOutlineBlankOutlinedIcon /> Show all benchmarks
+                </span>
+              ) : null}
               <span
                 className={`${$button.pilled}`}
                 style={{
@@ -86,7 +99,16 @@ function Benchmarks() {
             {tasks?.map((task) => {
               return (
                 <div key={task.task_id} className={$typo.noDecoration}>
-                  <TaskCard task={task} />
+                  {isPara ? (
+                    <Link
+                      href={`/benchmarks/${task.task_id}`}
+                      style={{ color: "black", textDecoration: "none" }}
+                    >
+                      <TaskCard task={task} isPara={isPara} />
+                    </Link>
+                  ) : (
+                    <TaskCard task={task} isPara={isPara} />
+                  )}
                 </div>
               );
             })}

--- a/src/styles/Box.module.css
+++ b/src/styles/Box.module.css
@@ -17,7 +17,7 @@
 .inactive {
   composes: default;
   background-color: var(--grey-80);
-  border: none;
+  /* border: none; */
   color: var(--grey-50);
 }
 


### PR DESCRIPTION
#303

Following [This Design](https://www.figma.com/file/m09znscRXNqSziAiEbNLTf/Compass-Designs?type=design&node-id=12340-23722&mode=design&t=CFJtAF1N0loNBF5Q-4) for Data Collection

- Added Assign Tab in Nav bar
- Adjusted icons
- Edit Task Cards
- Added Toggle View for CM & Para for Benchmarks page only
- Add Placeholders for Search, Filter, Sort

Also, nothing has been done to the data collection page yet. Waiting for the benchmark creation to be completed to use the data for the instructions page.

https://github.com/sfbrigade/compass/assets/104481165/cb8aae01-7f15-45ea-abb4-96fe173c4ba0