### PR TITLE
Fix add student error logic

### DIFF
--- a/src/backend/lib/db_helpers/case_manager.ts
+++ b/src/backend/lib/db_helpers/case_manager.ts
@@ -102,6 +102,13 @@ type createStudentProps = {
   userId: string;
 };
 
+export const STUDENT_ASSIGNED_TO_YOU_ERR = new Error(
+  "This student is already assigned to you"
+);
+export const STUDENT_ALREADY_ASSIGNED_ERR = new Error(
+  "This student is already assigned to a case manager. Please check your roster if the student is already there. Otherwise, this student is with another case manager."
+);
+
 /**
  * Check for the existence of a student by email,
  * if they do not exist, create them as a student
@@ -124,13 +131,11 @@ export async function createAndAssignStudent({
   if (lookahead.length > 0) {
     const student = lookahead[0];
     if (student.assigned_case_manager_id === userId) {
-      throw new Error("This student is already assigned to you");
+      throw STUDENT_ASSIGNED_TO_YOU_ERR;
     }
     // not null
     else if (student.assigned_case_manager_id) {
-      throw new Error(
-        "This student is already assigned to a case manager. Please check your roster if the student is already there. Otherwise, this student is with another case manager."
-      );
+      throw STUDENT_ALREADY_ASSIGNED_ERR;
     }
     // if student exists in table, but is unassigned,
     // handle in onConflict during creation

--- a/src/backend/lib/db_helpers/case_manager.ts
+++ b/src/backend/lib/db_helpers/case_manager.ts
@@ -106,7 +106,7 @@ export const STUDENT_ASSIGNED_TO_YOU_ERR = new Error(
   "This student is already assigned to you"
 );
 export const STUDENT_ALREADY_ASSIGNED_ERR = new Error(
-  "This student is already assigned to a case manager. Please check your roster if the student is already there. Otherwise, this student is with another case manager."
+  "This student is already assigned to another case manager."
 );
 
 /**

--- a/src/backend/lib/db_helpers/case_manager.ts
+++ b/src/backend/lib/db_helpers/case_manager.ts
@@ -92,3 +92,66 @@ export async function assignParaToCaseManager(
 
   return;
 }
+
+type createStudentProps = {
+  first_name: string;
+  last_name: string;
+  email: string;
+  grade: number;
+  db: KyselyDatabaseInstance;
+  userId: string;
+};
+
+/**
+ * Check for the existence of a student by email,
+ * if they do not exist, create them as a student
+ * assigned to the given case manager
+ */
+export async function createAndAssignStudent({
+  first_name,
+  last_name,
+  email,
+  grade,
+  db,
+  userId,
+}: createStudentProps) {
+  const lookahead = await db
+    .selectFrom("student")
+    .selectAll()
+    .where("email", "=", email)
+    .execute();
+
+  if (lookahead.length > 0) {
+    const student = lookahead[0];
+    if (student.assigned_case_manager_id === userId) {
+      throw new Error("This student is already assigned to you");
+    }
+    // not null
+    else if (student.assigned_case_manager_id) {
+      throw new Error(
+        "This student is already assigned to a case manager. Please check your roster if the student is already there. Otherwise, this student is with another case manager."
+      );
+    }
+    // if student exists in table, but is unassigned,
+    // handle in onConflict during creation
+  }
+
+  // else, safe to create or re-assign student
+  await db
+    .insertInto("student")
+    .values({
+      first_name,
+      last_name,
+      email: email.toLowerCase(),
+      assigned_case_manager_id: userId,
+      grade,
+    })
+    .onConflict((oc) =>
+      oc
+        .column("email")
+        .doUpdateSet({ assigned_case_manager_id: userId })
+        .where("student.assigned_case_manager_id", "is", null)
+    )
+    .returningAll()
+    .executeTakeFirstOrThrow();
+}

--- a/src/backend/routers/case_manager.test.ts
+++ b/src/backend/routers/case_manager.test.ts
@@ -122,12 +122,6 @@ test("addStudent - student exists in db but is unassigned", async (t) => {
       .executeTakeFirst()
   );
 
-  await db
-    .selectFrom("student")
-    .where("first_name", "=", seed.student.first_name)
-    .selectAll()
-    .executeTakeFirst();
-
   await trpc.case_manager.addStudent.mutate({
     first_name: seed.student.first_name,
     last_name: seed.student.last_name,

--- a/src/backend/routers/case_manager.test.ts
+++ b/src/backend/routers/case_manager.test.ts
@@ -1,6 +1,11 @@
 import test from "ava";
 import { getTestServer } from "@/backend/tests";
 
+import {
+  STUDENT_ASSIGNED_TO_YOU_ERR,
+  STUDENT_ALREADY_ASSIGNED_ERR,
+} from "@/backend/lib/db_helpers/case_manager";
+
 test("getMyStudents", async (t) => {
   const { trpc, db, seed } = await getTestServer(t, {
     authenticateAs: "case_manager",
@@ -102,7 +107,7 @@ test("addStudent - student doesn't exist in db", async (t) => {
   t.is(myStudentsAfter.length, 1);
 });
 
-test("addStudent - student exists in db", async (t) => {
+test("addStudent - student exists in db but is unassigned", async (t) => {
   const { trpc, db, seed } = await getTestServer(t, {
     authenticateAs: "case_manager",
   });
@@ -116,6 +121,12 @@ test("addStudent - student exists in db", async (t) => {
       .selectAll()
       .executeTakeFirst()
   );
+
+  await db
+    .selectFrom("student")
+    .where("first_name", "=", seed.student.first_name)
+    .selectAll()
+    .executeTakeFirst();
 
   await trpc.case_manager.addStudent.mutate({
     first_name: seed.student.first_name,
@@ -137,12 +148,117 @@ test("addStudent - student exists in db", async (t) => {
   );
 });
 
+test("addStudent - student exists in db and is already assigned to user", async (t) => {
+  const { trpc, seed } = await getTestServer(t, {
+    authenticateAs: "case_manager",
+  });
+
+  const studentsBefore = await trpc.case_manager.getMyStudents.query();
+  t.is(studentsBefore.length, 0);
+
+  await trpc.case_manager.addStudent.mutate({
+    first_name: seed.student.first_name,
+    last_name: seed.student.last_name,
+    email: seed.student.email,
+    grade: seed.student.grade,
+  });
+
+  const studentsAfter = await trpc.case_manager.getMyStudents.query();
+  t.is(studentsAfter.length, 1);
+
+  // this should be a duplicate operation, student's email should already be assigned to this user
+  const err = await t.throwsAsync(
+    trpc.case_manager.addStudent.mutate({
+      first_name: seed.student.first_name,
+      last_name: seed.student.last_name,
+      email: seed.student.email,
+      grade: seed.student.grade,
+    })
+  );
+
+  t.is(err?.message, STUDENT_ASSIGNED_TO_YOU_ERR.message);
+});
+
+test("addStudent - student exists in db but is assigned to another case manager", async (t) => {
+  const { trpc, db, seed } = await getTestServer(t, {
+    authenticateAs: "case_manager",
+  });
+
+  const studentsBefore = await trpc.case_manager.getMyStudents.query();
+  t.is(studentsBefore.length, 0);
+
+  // create alternative case manager
+  const fakeCM = await db
+    .insertInto("user")
+    .values({
+      first_name: "Fake",
+      last_name: "CM",
+      role: "admin",
+      email: "fakecm@test.com",
+    })
+    .returningAll()
+    .executeTakeFirst();
+
+  t.truthy(fakeCM?.user_id);
+
+  const newStudent = {
+    first_name: "New",
+    last_name: "Student",
+    email: "ns@gmail.com",
+    grade: 1,
+    assigned_case_manager_id: fakeCM!.user_id,
+  };
+
+  const studentCheck = await db
+    .selectFrom("student")
+    .selectAll()
+    .where("email", "=", newStudent.email)
+    .execute();
+
+  t.is(studentCheck.length, 0);
+
+  // assign student to new case manager
+  await db.insertInto("student").values(newStudent).execute();
+
+  // this student's email should already be assigned to the alternative case manager
+  const err = await t.throwsAsync(
+    trpc.case_manager.addStudent.mutate({
+      first_name: newStudent.first_name,
+      last_name: newStudent.last_name,
+      email: newStudent.email,
+      grade: newStudent.grade,
+    })
+  );
+
+  t.is(err?.message, STUDENT_ALREADY_ASSIGNED_ERR.message);
+
+  // reassign student to user
+  await db
+    .updateTable("student")
+    .set({ assigned_case_manager_id: seed.case_manager.user_id })
+    .where("email", "=", newStudent.email)
+    .returningAll()
+    .execute();
+
+  // perform redundant assignment to user
+  const redundantErr = await t.throwsAsync(
+    trpc.case_manager.addStudent.mutate({
+      first_name: newStudent.first_name,
+      last_name: newStudent.last_name,
+      email: newStudent.email,
+      grade: newStudent.grade,
+    })
+  );
+
+  t.is(redundantErr?.message, STUDENT_ASSIGNED_TO_YOU_ERR.message);
+});
+
 test("addStudent - invalid email", async (t) => {
   const { trpc } = await getTestServer(t, {
     authenticateAs: "case_manager",
   });
 
-  await t.throwsAsync(
+  const err = await t.throwsAsync(
     trpc.case_manager.addStudent.mutate({
       first_name: "Foo",
       last_name: "Bar",
@@ -150,6 +266,21 @@ test("addStudent - invalid email", async (t) => {
       grade: 6,
     })
   );
+  // should be zod error
+  t.is(typeof err?.message, "string");
+  const parsed = (JSON.parse(err?.message as string) || []) as Array<{
+    [index: string]: string;
+  }>;
+  if (parsed instanceof Array && parsed.length > 0) {
+    t.deepEqual(parsed[0], {
+      validation: "email",
+      code: "invalid_string",
+      message: "Invalid email",
+      path: ["email"],
+    });
+  } else {
+    t.fail();
+  }
 });
 
 test("removeStudent", async (t) => {

--- a/src/backend/routers/case_manager.ts
+++ b/src/backend/routers/case_manager.ts
@@ -3,6 +3,7 @@ import { authenticatedProcedure, router } from "../trpc";
 import {
   createPara,
   assignParaToCaseManager,
+  createAndAssignStudent,
 } from "../lib/db_helpers/case_manager";
 
 export const case_manager = router({
@@ -62,23 +63,29 @@ export const case_manager = router({
       const { first_name, last_name, email, grade } = req.input;
       const { userId } = req.ctx.auth;
 
-      await req.ctx.db
-        .insertInto("student")
-        .values({
-          first_name,
-          last_name,
-          email: email.toLowerCase(),
-          assigned_case_manager_id: userId,
-          grade,
-        })
-        .onConflict((oc) =>
-          oc
-            .column("email")
-            .doUpdateSet({ assigned_case_manager_id: userId })
-            .where("student.assigned_case_manager_id", "is", null)
-        )
-        .returningAll()
-        .executeTakeFirstOrThrow();
+      await createAndAssignStudent({
+        ...req.input,
+        userId,
+        db: req.ctx.db,
+      });
+
+      // await req.ctx.db
+      //   .insertInto("student")
+      //   .values({
+      //     first_name,
+      //     last_name,
+      //     email: email.toLowerCase(),
+      //     assigned_case_manager_id: userId,
+      //     grade,
+      //   })
+      //   .onConflict((oc) =>
+      //     oc
+      //       .column("email")
+      //       .doUpdateSet({ assigned_case_manager_id: userId })
+      //       .where("student.assigned_case_manager_id", "is", null)
+      //   )
+      //   .returningAll()
+      //   .executeTakeFirstOrThrow();
     }),
 
   /**

--- a/src/backend/routers/case_manager.ts
+++ b/src/backend/routers/case_manager.ts
@@ -60,7 +60,6 @@ export const case_manager = router({
       })
     )
     .mutation(async (req) => {
-      const { first_name, last_name, email, grade } = req.input;
       const { userId } = req.ctx.auth;
 
       await createAndAssignStudent({
@@ -68,24 +67,6 @@ export const case_manager = router({
         userId,
         db: req.ctx.db,
       });
-
-      // await req.ctx.db
-      //   .insertInto("student")
-      //   .values({
-      //     first_name,
-      //     last_name,
-      //     email: email.toLowerCase(),
-      //     assigned_case_manager_id: userId,
-      //     grade,
-      //   })
-      //   .onConflict((oc) =>
-      //     oc
-      //       .column("email")
-      //       .doUpdateSet({ assigned_case_manager_id: userId })
-      //       .where("student.assigned_case_manager_id", "is", null)
-      //   )
-      //   .returningAll()
-      //   .executeTakeFirstOrThrow();
     }),
 
   /**


### PR DESCRIPTION
In reference to issue #327, moves bulk of logic from routers/case_manager `addStudent` procedure over to lib/db_helpers/case_manager `createAndAssignStudent` function. Also creates specific errors, which are thrown by the new function to allow better information for the client to display. There is no client aspect to this PR, though making that final connection could easily be added to this PR. Also adds several additional tests on the routers/case_manager.test.ts to ensure that the correct errors are being thrown in the correct circumstances.