### PR TITLE
Fixed check for iep end date- resolution to [ENG] #316 issue

### DIFF
--- a/src/pages/students/[student_id].tsx
+++ b/src/pages/students/[student_id].tsx
@@ -351,7 +351,7 @@ const ViewStudentPage = () => {
                             type="date"
                             name="end_date"
                             defaultValue={endDate}
-                            inputProps={{ min: { startDate } }}
+                            inputProps={{ min: startDate }}
                             required
                           />
                         </Container>


### PR DESCRIPTION
Change to allow for proper check of the min IEP date.
Now, the end IEP dates are greyed out to prevent selection of a date that is less than the start IEP date.

Before:
![image](https://github.com/sfbrigade/compass/assets/32425204/c54a778e-14fa-4216-9ffc-6e2ebfe76574)


After:
![image](https://github.com/sfbrigade/compass/assets/32425204/186cd2c9-0151-4d27-aa75-134100c7be3d)
