### PR TITLE
added check and test for IEP end dates

### DIFF
--- a/src/backend/db/migrations/1_initial-migrations.sql
+++ b/src/backend/db/migrations/1_initial-migrations.sql
@@ -64,6 +64,7 @@ CREATE TABLE "iep" (
   case_manager_id UUID REFERENCES "user" (user_id),
   start_date DATE NOT NULL,
   end_date DATE NOT NULL,
+    CHECK (end_date >= start_date),
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
@@ -79,8 +80,8 @@ CREATE TABLE "goal" (
 CREATE TABLE "subgoal" (
   subgoal_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(), -- TODO: add index to allow reordering
   goal_id UUID REFERENCES "goal" (goal_id),
-  status TEXT NOT NULL DEFAULT 'In Progress' 
-    CHECK (status IN ('In Progress', 'Complete')), 
+  status TEXT NOT NULL DEFAULT 'In Progress'
+    CHECK (status IN ('In Progress', 'Complete')),
   description TEXT NOT NULL,
   setup TEXT NOT NULL,
   instructions TEXT NOT NULL DEFAULT '',


### PR DESCRIPTION
Added check to IEP table schema in initial_migrations to make sure end date is greater than or equal to start date. created test in student.test.ts to check that having a smaller end date will throw an error when creating a new IEP or editing an IEP.