### PR TITLE
Fix #369: Fixed Javascript console warnings on Create Benchmark page

### DIFF
--- a/src/pages/students/[student_id]/goals/[goal_id]/create.tsx
+++ b/src/pages/students/[student_id]/goals/[goal_id]/create.tsx
@@ -42,7 +42,7 @@ const CreateBenchmarkPage = () => {
   const router = useRouter();
   const { data: goal } = trpc.iep.getGoal.useQuery(
     { goal_id: router.query.goal_id as string },
-    { enabled: Boolean(router.query.goal_id) },
+    { enabled: Boolean(router.query.goal_id) }
   );
 
   const addSubgoalMutation = trpc.iep.addSubgoal.useMutation();
@@ -121,7 +121,7 @@ const CreateBenchmarkPage = () => {
       await router.push(
         `/students/${router.query.student_id as string}/goals/${
           router.query.goal_id as string
-        }`,
+        }`
       );
     } catch (error) {
       console.error("Error creating benchmark", error);

--- a/src/pages/students/[student_id]/goals/[goal_id]/create.tsx
+++ b/src/pages/students/[student_id]/goals/[goal_id]/create.tsx
@@ -7,6 +7,7 @@ import {
   Box,
   Stack,
   Step,
+  StepIconProps,
   StepLabel,
   Stepper,
   TextField,
@@ -27,11 +28,21 @@ interface BenchmarkFormEntry {
   [key: string]: string | number | "";
 }
 
+const BenchmarkStepperIcon = (stepIconProps: StepIconProps) => {
+  const { completed = false } = stepIconProps;
+
+  if (completed) {
+    return <CheckCircle />;
+  } else {
+    return <TripOriginRounded />;
+  }
+};
+
 const CreateBenchmarkPage = () => {
   const router = useRouter();
   const { data: goal } = trpc.iep.getGoal.useQuery(
     { goal_id: router.query.goal_id as string },
-    { enabled: Boolean(router.query.goal_id) }
+    { enabled: Boolean(router.query.goal_id) },
   );
 
   const addSubgoalMutation = trpc.iep.addSubgoal.useMutation();
@@ -110,7 +121,7 @@ const CreateBenchmarkPage = () => {
       await router.push(
         `/students/${router.query.student_id as string}/goals/${
           router.query.goal_id as string
-        }`
+        }`,
       );
     } catch (error) {
       console.error("Error creating benchmark", error);
@@ -176,11 +187,7 @@ const CreateBenchmarkPage = () => {
           multiline
           rows={4}
           name={field.name}
-          value={
-            benchmarkFormState[field.name] !== ""
-              ? benchmarkFormState[field.name]
-              : null
-          }
+          value={benchmarkFormState[field.name] || ""}
           onChange={(e: ChangeEvent) =>
             setBenchmarkFormState({
               ...benchmarkFormState,
@@ -218,17 +225,11 @@ const CreateBenchmarkPage = () => {
           Create Benchmark
         </Typography>
         <Stepper activeStep={viewState} alternativeLabel connector={null}>
-          {steps.map((label, index) => (
+          {steps.map((label) => (
             <Step key={label}>
-              {index !== steps.length && (
-                <StepLabel
-                  StepIconComponent={
-                    index < viewState ? CheckCircle : TripOriginRounded
-                  }
-                >
-                  {label}
-                </StepLabel>
-              )}
+              <StepLabel StepIconComponent={BenchmarkStepperIcon}>
+                {label}
+              </StepLabel>
             </Step>
           ))}
         </Stepper>
@@ -263,11 +264,7 @@ const CreateBenchmarkPage = () => {
                       required
                       type="number"
                       name="baseline_level"
-                      value={
-                        benchmarkFormState["baseline_level"] !== ""
-                          ? benchmarkFormState["baseline_level"]
-                          : ""
-                      }
+                      value={benchmarkFormState["baseline_level"] || ""}
                       onChange={(e: ChangeEvent) =>
                         setBenchmarkFormState({
                           ...benchmarkFormState,
@@ -283,11 +280,7 @@ const CreateBenchmarkPage = () => {
                       required
                       type="number"
                       name="target_level"
-                      value={
-                        benchmarkFormState["target_level"] !== ""
-                          ? benchmarkFormState["target_level"]
-                          : ""
-                      }
+                      value={benchmarkFormState["target_level"] || ""}
                       onChange={(e: ChangeEvent) =>
                         setBenchmarkFormState({
                           ...benchmarkFormState,
@@ -302,11 +295,7 @@ const CreateBenchmarkPage = () => {
                     type="number"
                     name="attempts_per_trial"
                     required
-                    value={
-                      benchmarkFormState["attempts_per_trial"] !== ""
-                        ? benchmarkFormState["attempts_per_trial"]
-                        : ""
-                    }
+                    value={benchmarkFormState["attempts_per_trial"] || ""}
                     onChange={(e: ChangeEvent) =>
                       setBenchmarkFormState({
                         ...benchmarkFormState,
@@ -319,11 +308,7 @@ const CreateBenchmarkPage = () => {
                     type="number"
                     name="number_of_trials"
                     required
-                    value={
-                      benchmarkFormState["number_of_trials"] !== ""
-                        ? benchmarkFormState["number_of_trials"]
-                        : ""
-                    }
+                    value={benchmarkFormState["number_of_trials"] || ""}
                     onChange={(e: ChangeEvent) =>
                       setBenchmarkFormState({
                         ...benchmarkFormState,


### PR DESCRIPTION
I found saw warnings when loading the "Create Benchmark" page, captured in this file:

[369_browser_console_warnings.log](https://github.com/user-attachments/files/16606471/369_browser_console_warnings.log)

These three appear to be caused by the Stepper expecting the icon components exp:
```
hydration-error-info.js:63 Warning: Received `false` for a non-boolean attribute `completed`.
hydration-error-info.js:63 Warning: Received `true` for a non-boolean attribute `active`.
hydration-error-info.js:63 Warning: Received `false` for a non-boolean attribute `error`.
```

This warning appears to be caused by the value property of a `TextArea` defaulting to `null`:
```
hydration-error-info.js:63 Warning: `value` prop on `textarea` should not be null. Consider using an empty string to clear the component or `undefined` for uncontrolled components.
```