### PR TITLE
Prompt for Google account selection every time on log in.

### DIFF
--- a/src/backend/auth/options.ts
+++ b/src/backend/auth/options.ts
@@ -10,6 +10,11 @@ export const getNextAuthOptions = (
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID as string,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
+      authorization: {
+        params: {
+          prompt: "login", // Prompt for Google sign-in ("Choose an account") every time on log in.
+        },
+      },
     }),
   ],
   adapter: createPersistedAuthAdapter(db),


### PR DESCRIPTION
*(I think this change is probably a good idea, but would like to hear what others think, so I've left it as a draft PR for now.)*

Currently, when you logout of Compass, and then sign in again with the "Sign in with Google" buton on the Sign In page, the Students page is loaded immediately without prompting for confirmation or selection of which Google account to use.

I figured out how to force the Google NextAuth provider to prompt for Google account selection and confirmation every time the "Sign in with Google" button is clicked. Note that if a user never logs out of Compass or clears their auth cookies, they will still stay signed in.

For what it's worth, I checked the behavior of the Logout link in Figma using Google SSO, and it also prompts for account selection and confirmation when logging back in afterward.

Before this change:

https://github.com/user-attachments/assets/95db3de1-6972-46bf-9e5e-1ded26597595

After this change:


https://github.com/user-attachments/assets/0c9bb1aa-0ff8-40a2-a0eb-1f4341125931

