### PR TITLE
[Closes #434] Adds Mailcatcher to Docker supporting services for local email development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,5 +16,9 @@ S3_USER_UPLOADS_ACCESS_KEY_ID=minioadmin
 S3_USER_UPLOADS_SECRET_ACCESS_KEY=minioadmin
 S3_USER_UPLOADS_BUCKET_NAME=compass-files
 
-EMAIL=no.reply.project.compass@gmail.com
-EMAIL_PASS=
+EMAIL_SERVICE=smtp
+EMAIL_AUTH_USER=
+EMAIL_AUTH_PASS=
+EMAIL_FROM=no-reply@compassiep.org
+EMAIL_HOST=localhost
+EMAIL_PORT=1025

--- a/src/backend/auth/adapter.ts
+++ b/src/backend/auth/adapter.ts
@@ -7,7 +7,7 @@ import {
 import { InsertObject, Selectable } from "kysely";
 
 const mapStoredUserToAdapterUser = (
-  user: Selectable<ZapatosTableNameToKyselySchema<"user">>
+  user: Selectable<ZapatosTableNameToKyselySchema<"user">>,
 ): AdapterUser => ({
   id: user.user_id,
   email: user.email,
@@ -17,7 +17,7 @@ const mapStoredUserToAdapterUser = (
 });
 
 const mapStoredSessionToAdapterSession = (
-  session: Selectable<ZapatosTableNameToKyselySchema<"session">>
+  session: Selectable<ZapatosTableNameToKyselySchema<"session">>,
 ): AdapterSession => ({
   sessionToken: session.session_token,
   userId: session.user_id,
@@ -32,7 +32,7 @@ const mapStoredSessionToAdapterSession = (
  * See https://next-auth.js.org/tutorials/creating-a-database-adapter
  */
 export const createPersistedAuthAdapter = (
-  db: KyselyDatabaseInstance
+  db: KyselyDatabaseInstance,
 ): Adapter => ({
   async createUser(user) {
     const numOfUsers = await db
@@ -149,7 +149,7 @@ export const createPersistedAuthAdapter = (
       .insertInto("account")
       .values(data)
       .onConflict((b) =>
-        b.columns(["provider_name", "provider_account_id"]).doUpdateSet(data)
+        b.columns(["provider_name", "provider_account_id"]).doUpdateSet(data),
       )
       .execute();
   },

--- a/src/backend/auth/options.ts
+++ b/src/backend/auth/options.ts
@@ -4,7 +4,7 @@ import { KyselyDatabaseInstance } from "../lib";
 import type { NextAuthOptions } from "next-auth";
 
 export const getNextAuthOptions = (
-  db: KyselyDatabaseInstance
+  db: KyselyDatabaseInstance,
 ): NextAuthOptions => ({
   providers: [
     GoogleProvider({

--- a/src/backend/context.ts
+++ b/src/backend/context.ts
@@ -23,7 +23,7 @@ export type tRPCContext = ReturnType<typeof getDb> & {
 };
 
 export const createContext = async (
-  options: CreateNextContextOptions
+  options: CreateNextContextOptions,
 ): Promise<tRPCContext> => {
   const env = (options.req.env as unknown as Env) ?? process.env;
   const {
@@ -40,7 +40,7 @@ export const createContext = async (
   const session = await getServerSession(
     options.req,
     options.res,
-    getNextAuthOptions(db)
+    getNextAuthOptions(db),
   );
   if (session && session.user?.email) {
     const user = await db

--- a/src/backend/db/lib/migrate.ts
+++ b/src/backend/db/lib/migrate.ts
@@ -11,11 +11,11 @@ interface MigrateOptions {
 
 export const migrate = async (
   databaseUrl: string,
-  { silent = false, shouldGenerateTypes = true }: MigrateOptions = {}
+  { silent = false, shouldGenerateTypes = true }: MigrateOptions = {},
 ) => {
   const migrationsDirectory = path.join(
     process.cwd(),
-    "src/backend/db/migrations"
+    "src/backend/db/migrations",
   );
   const zapatosDirectory = path.join(process.cwd(), "src/backend/db");
 

--- a/src/backend/db/lib/seed.test.ts
+++ b/src/backend/db/lib/seed.test.ts
@@ -20,7 +20,7 @@ test("seedfile works with current schema", async (t) => {
     t.fail(
       `Seedfile execution failed: ${
         error instanceof Error ? error.message : String(error)
-      }`
+      }`,
     );
   } finally {
     await db.destroy();

--- a/src/backend/lib/db_helpers/case_manager.ts
+++ b/src/backend/lib/db_helpers/case_manager.ts
@@ -20,7 +20,7 @@ export async function createPara(
   case_manager_id: string,
   from_email: string,
   to_email: string,
-  env: Env
+  env: Env,
 ): Promise<user.Selectable | undefined> {
   const { first_name, last_name, email } = para;
 
@@ -48,7 +48,7 @@ export async function createPara(
       to_email,
       first_name,
       case_manager_id,
-      env
+      env,
     );
   }
 
@@ -63,7 +63,7 @@ export async function sendInviteEmail(
   toEmail: string,
   first_name: string,
   caseManagerName: string,
-  env: Env
+  env: Env,
 ): Promise<void> {
   await getTransporter(env).sendMail({
     from: fromEmail,
@@ -83,7 +83,7 @@ export async function sendInviteEmail(
 export async function assignParaToCaseManager(
   para_id: string,
   case_manager_id: string,
-  db: KyselyDatabaseInstance
+  db: KyselyDatabaseInstance,
 ): Promise<void> {
   await db
     .insertInto("paras_assigned_to_case_manager")
@@ -103,10 +103,10 @@ type createStudentProps = {
 };
 
 export const STUDENT_ASSIGNED_TO_YOU_ERR = new Error(
-  "This student is already assigned to you"
+  "This student is already assigned to you",
 );
 export const STUDENT_ALREADY_ASSIGNED_ERR = new Error(
-  "This student is already assigned to another case manager."
+  "This student is already assigned to another case manager.",
 );
 
 /**
@@ -155,7 +155,7 @@ export async function createAndAssignStudent({
       oc
         .column("email")
         .doUpdateSet({ assigned_case_manager_id: userId })
-        .where("student.assigned_case_manager_id", "is", null)
+        .where("student.assigned_case_manager_id", "is", null),
     )
     .returningAll()
     .executeTakeFirstOrThrow();

--- a/src/backend/lib/files.ts
+++ b/src/backend/lib/files.ts
@@ -4,7 +4,7 @@ import { substituteTransactionOnContext } from "./utils/context";
 
 const deleteFileWithoutTransaction = async (
   fileId: string,
-  ctx: tRPCContext
+  ctx: tRPCContext,
 ) => {
   if (ctx.auth.type === "none") {
     throw new Error("File deletion requires authentication.");
@@ -21,7 +21,7 @@ const deleteFileWithoutTransaction = async (
     new DeleteObjectCommand({
       Bucket: ctx.env.S3_USER_UPLOADS_BUCKET_NAME,
       Key: ext_s3_path,
-    })
+    }),
   );
 };
 
@@ -33,7 +33,7 @@ export const deleteFile = async (fileId: string, ctx: tRPCContext) => {
   await ctx.db.transaction().execute(async (trx) => {
     await deleteFileWithoutTransaction(
       fileId,
-      substituteTransactionOnContext(trx, ctx)
+      substituteTransactionOnContext(trx, ctx),
     );
   });
 };

--- a/src/backend/lib/logger.ts
+++ b/src/backend/lib/logger.ts
@@ -9,8 +9,8 @@ export const logger = winston.createLogger({
         winston.format.timestamp(),
         winston.format.printf(
           ({ level, message, timestamp }) =>
-            `${timestamp as string} ${level}: ${message as string}`
-        )
+            `${timestamp as string} ${level}: ${message as string}`,
+        ),
       ),
     }),
   ],

--- a/src/backend/lib/nodemailer.ts
+++ b/src/backend/lib/nodemailer.ts
@@ -1,11 +1,18 @@
 import { createTransport } from "nodemailer";
+import SMTPTransport from "nodemailer/lib/smtp-transport";
 import { Env } from "./types";
 
-export const getTransporter = (environment: Env) =>
-  createTransport({
-    service: "gmail",
+export const getTransporter = (env: Env) => {
+  const options: SMTPTransport.Options = {
+    service: env.EMAIL_SERVICE,
     auth: {
-      user: environment.EMAIL,
-      pass: environment.EMAIL_PASS,
+      user: env.EMAIL_AUTH_USER,
+      pass: env.EMAIL_AUTH_PASS,
     },
-  });
+  };
+  if (env.EMAIL_SERVICE === "smtp") {
+    options.host = env.EMAIL_HOST;
+    options.port = parseInt(env.EMAIL_PORT, 10);
+  }
+  return createTransport(options);
+};

--- a/src/backend/lib/types/env.ts
+++ b/src/backend/lib/types/env.ts
@@ -5,6 +5,10 @@ export interface Env {
   S3_USER_UPLOADS_ACCESS_KEY_ID: string;
   S3_USER_UPLOADS_SECRET_ACCESS_KEY: string;
   S3_USER_UPLOADS_BUCKET_NAME: string;
-  EMAIL: string;
-  EMAIL_PASS: string;
+  EMAIL_SERVICE: string;
+  EMAIL_AUTH_USER: string;
+  EMAIL_AUTH_PASS: string;
+  EMAIL_FROM: string;
+  EMAIL_HOST: string;
+  EMAIL_PORT: string;
 }

--- a/src/backend/lib/utils/context.ts
+++ b/src/backend/lib/utils/context.ts
@@ -4,7 +4,7 @@ import { KyselySchema } from "../types";
 
 export const substituteTransactionOnContext = (
   trx: Transaction<KyselySchema>,
-  context: tRPCContext
+  context: tRPCContext,
 ): tRPCContext => ({
   ...context,
   db: trx,

--- a/src/backend/routers/admin.ts
+++ b/src/backend/routers/admin.ts
@@ -4,7 +4,7 @@ import { adminProcedure, router } from "../trpc";
 export const admin = router({
   getPostgresInfo: adminProcedure.query(async (req) => {
     const result = await sql<{ version: string }>`SELECT version()`.execute(
-      req.ctx.db
+      req.ctx.db,
     );
 
     return result.rows[0].version;

--- a/src/backend/routers/case_manager.test.ts
+++ b/src/backend/routers/case_manager.test.ts
@@ -93,7 +93,7 @@ test("addStudent - student doesn't exist in db", async (t) => {
       .selectFrom("student")
       .where("first_name", "=", "Foo")
       .selectAll()
-      .executeTakeFirst()
+      .executeTakeFirst(),
   );
 
   await trpc.case_manager.addStudent.mutate({
@@ -119,7 +119,7 @@ test("addStudent - student exists in db but is unassigned", async (t) => {
       .selectFrom("student")
       .where("first_name", "=", seed.student.first_name)
       .selectAll()
-      .executeTakeFirst()
+      .executeTakeFirst(),
   );
 
   await trpc.case_manager.addStudent.mutate({
@@ -138,7 +138,7 @@ test("addStudent - student exists in db but is unassigned", async (t) => {
       .where("student_id", "=", seed.student.student_id)
       .where("assigned_case_manager_id", "=", seed.case_manager.user_id)
       .selectAll()
-      .executeTakeFirstOrThrow()
+      .executeTakeFirstOrThrow(),
   );
 });
 
@@ -167,7 +167,7 @@ test("addStudent - student exists in db and is already assigned to user", async 
       last_name: seed.student.last_name,
       email: seed.student.email,
       grade: seed.student.grade,
-    })
+    }),
   );
 
   t.is(err?.message, STUDENT_ASSIGNED_TO_YOU_ERR.message);
@@ -221,7 +221,7 @@ test("addStudent - student exists in db but is assigned to another case manager"
       last_name: newStudent.last_name,
       email: newStudent.email,
       grade: newStudent.grade,
-    })
+    }),
   );
 
   t.is(err?.message, STUDENT_ALREADY_ASSIGNED_ERR.message);
@@ -241,7 +241,7 @@ test("addStudent - student exists in db but is assigned to another case manager"
       last_name: newStudent.last_name,
       email: newStudent.email,
       grade: newStudent.grade,
-    })
+    }),
   );
 
   t.is(redundantErr?.message, STUDENT_ASSIGNED_TO_YOU_ERR.message);
@@ -258,7 +258,7 @@ test("addStudent - invalid email", async (t) => {
       last_name: "Bar",
       email: "invalid-email",
       grade: 6,
-    })
+    }),
   );
   // should be zod error
   t.is(typeof err?.message, "string");

--- a/src/backend/routers/case_manager.ts
+++ b/src/backend/routers/case_manager.ts
@@ -28,7 +28,7 @@ export const case_manager = router({
     const studentData = await req.ctx.db
       .selectFrom("iep")
       .fullJoin("student", (join) =>
-        join.onRef("student.student_id", "=", "iep.student_id")
+        join.onRef("student.student_id", "=", "iep.student_id"),
       )
       .where("assigned_case_manager_id", "=", userId)
       .select([
@@ -57,7 +57,7 @@ export const case_manager = router({
         last_name: z.string(),
         email: z.string().email(),
         grade: z.number(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const { userId } = req.ctx.auth;
@@ -80,7 +80,7 @@ export const case_manager = router({
         last_name: z.string(),
         email: z.string().email(),
         grade: z.number(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const { student_id, first_name, last_name, email, grade } = req.input;
@@ -119,7 +119,7 @@ export const case_manager = router({
     .input(
       z.object({
         student_id: z.string(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const { student_id } = req.input;
@@ -139,7 +139,7 @@ export const case_manager = router({
       .innerJoin(
         "paras_assigned_to_case_manager",
         "user.user_id",
-        "paras_assigned_to_case_manager.para_id"
+        "paras_assigned_to_case_manager.para_id",
       )
       .where("paras_assigned_to_case_manager.case_manager_id", "=", userId)
       .selectAll()
@@ -158,22 +158,22 @@ export const case_manager = router({
         first_name: z.string(),
         last_name: z.string(),
         email: z.string().email(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const para = await createPara(
         req.input,
         req.ctx.db,
         req.ctx.auth.userId,
-        req.ctx.env.EMAIL,
+        req.ctx.env.EMAIL_FROM,
         req.input.email,
-        req.ctx.env
+        req.ctx.env,
       );
 
       return await assignParaToCaseManager(
         para?.user_id || "",
         req.ctx.auth.userId,
-        req.ctx.db
+        req.ctx.db,
       );
     }),
 
@@ -184,13 +184,13 @@ export const case_manager = router({
     .input(
       z.object({
         para_id: z.string(),
-      })
+      }),
     )
     .mutation(async (req) => {
       await assignParaToCaseManager(
         req.input.para_id,
         req.ctx.auth.userId,
-        req.ctx.db
+        req.ctx.db,
       );
       return;
     }),
@@ -202,7 +202,7 @@ export const case_manager = router({
         first_name: z.string(),
         last_name: z.string(),
         email: z.string().email(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const { para_id, first_name, last_name, email } = req.input;
@@ -214,7 +214,7 @@ export const case_manager = router({
           .innerJoin(
             "paras_assigned_to_case_manager",
             "user.user_id",
-            "paras_assigned_to_case_manager.para_id"
+            "paras_assigned_to_case_manager.para_id",
           )
           .where("paras_assigned_to_case_manager.case_manager_id", "=", userId)
           .selectAll();
@@ -240,7 +240,7 @@ export const case_manager = router({
     .input(
       z.object({
         para_id: z.string(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const { para_id } = req.input;

--- a/src/backend/routers/file.test.ts
+++ b/src/backend/routers/file.test.ts
@@ -22,7 +22,7 @@ test("can upload files", async (t) => {
     await db
       .selectFrom("file")
       .where("ext_s3_path", "=", key)
-      .executeTakeFirst()
+      .executeTakeFirst(),
   );
 });
 

--- a/src/backend/routers/file.ts
+++ b/src/backend/routers/file.ts
@@ -22,7 +22,7 @@ export const file = router({
     .input(
       z.object({
         file_id: z.string().uuid(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const file = await req.ctx.db
@@ -54,7 +54,7 @@ export const file = router({
     .input(
       z.object({
         type: z.string(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const key = randomUUID();
@@ -76,7 +76,7 @@ export const file = router({
       z.object({
         filename: z.string(),
         key: z.string(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const command = new HeadObjectCommand({
@@ -103,7 +103,7 @@ export const file = router({
     .input(
       z.object({
         file_id: z.string().uuid(),
-      })
+      }),
     )
     .mutation(async (req) => {
       await deleteFile(req.input.file_id, req.ctx);

--- a/src/backend/routers/iep.test.ts
+++ b/src/backend/routers/iep.test.ts
@@ -84,7 +84,7 @@ test("basic flow - add/get goals, subgoals, tasks", async (t) => {
       .where("subgoal_id", "=", subgoal2Id)
       .where("assignee_id", "=", para_id)
       .selectAll()
-      .executeTakeFirstOrThrow()
+      .executeTakeFirstOrThrow(),
   );
 });
 

--- a/src/backend/routers/iep.ts
+++ b/src/backend/routers/iep.ts
@@ -13,7 +13,7 @@ export const iep = router({
         iep_id: z.string(),
         description: z.string(),
         category: z.string(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const { iep_id, description, category } = req.input;
@@ -36,7 +36,7 @@ export const iep = router({
       z.object({
         goal_id: z.string(),
         description: z.string(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const { goal_id, description } = req.input;
@@ -85,7 +85,7 @@ export const iep = router({
         metric_name: z.string(),
         attempts_per_trial: z.number().nullable(),
         number_of_trials: z.number().nullable(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const {
@@ -130,7 +130,7 @@ export const iep = router({
         assignee_id: z.string(),
         due_date: z.date(),
         trial_count: z.number(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const { subgoal_id, assignee_id, due_date, trial_count } = req.input;
@@ -155,7 +155,7 @@ export const iep = router({
         para_ids: z.string().uuid().array(),
         due_date: z.date().optional(),
         trial_count: z.number().optional(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const { subgoal_id, para_ids, due_date, trial_count } = req.input;
@@ -168,7 +168,7 @@ export const iep = router({
             assignee_id: para_id,
             due_date,
             trial_count,
-          }))
+          })),
         )
         .returningAll()
         .executeTakeFirst();
@@ -181,7 +181,7 @@ export const iep = router({
         subgoal_id: z.string(),
         due_date: z.date(),
         trial_count: z.number(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const { subgoal_id, due_date, trial_count } = req.input;
@@ -194,7 +194,7 @@ export const iep = router({
           eb.and([
             eb("subgoal_id", "=", subgoal_id),
             eb("assignee_id", "=", userId),
-          ])
+          ]),
         )
         .executeTakeFirst();
 
@@ -224,7 +224,7 @@ export const iep = router({
         success: z.number(),
         unsuccess: z.number(),
         notes: z.string(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const { userId } = req.ctx.auth;
@@ -254,7 +254,7 @@ export const iep = router({
         unsuccess: z.number().optional(),
         submitted: z.boolean().optional(),
         notes: z.string().optional(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const { trial_data_id, success, unsuccess, submitted, notes } = req.input;
@@ -275,7 +275,7 @@ export const iep = router({
     .input(
       z.object({
         iep_id: z.string(),
-      })
+      }),
     )
     .query(async (req) => {
       const { iep_id } = req.input;
@@ -293,7 +293,7 @@ export const iep = router({
     .input(
       z.object({
         goal_id: z.string(),
-      })
+      }),
     )
     .query(async (req) => {
       const { goal_id } = req.input;
@@ -311,7 +311,7 @@ export const iep = router({
     .input(
       z.object({
         goal_id: z.string(),
-      })
+      }),
     )
     .query(async (req) => {
       const { goal_id } = req.input;
@@ -329,7 +329,7 @@ export const iep = router({
     .input(
       z.object({
         subgoal_id: z.string(),
-      })
+      }),
     )
     .query(async (req) => {
       const { subgoal_id } = req.input;
@@ -346,7 +346,7 @@ export const iep = router({
     .input(
       z.object({
         assignee_id: z.string(),
-      })
+      }),
     )
     .query(async (req) => {
       const { assignee_id } = req.input;
@@ -365,7 +365,7 @@ export const iep = router({
     .input(
       z.object({
         task_id: z.string(),
-      })
+      }),
     )
     .query(async (req) => {
       const { task_id } = req.input;
@@ -405,18 +405,18 @@ export const iep = router({
                     .innerJoin(
                       "file",
                       "file.file_id",
-                      "trial_data_file.file_id"
+                      "trial_data_file.file_id",
                     )
-                    .selectAll("file")
+                    .selectAll("file"),
                 ).as("files"),
               ])
               .whereRef("trial_data.task_id", "=", "task.task_id")
               .whereRef(
                 "trial_data.created_by_user_id",
                 "=",
-                "task.assignee_id"
+                "task.assignee_id",
               )
-              .orderBy("trial_data.created_at")
+              .orderBy("trial_data.created_at"),
           ).as("trials"),
         ])
         .executeTakeFirstOrThrow();
@@ -428,7 +428,7 @@ export const iep = router({
     .input(
       z.object({
         task_id: z.string(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const { task_id } = req.input;
@@ -447,7 +447,7 @@ export const iep = router({
       z.object({
         trial_data_id: z.string(),
         file_id: z.string(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const { trial_data_id, file_id } = req.input;
@@ -466,7 +466,7 @@ export const iep = router({
       z.object({
         trial_data_id: z.string(),
         file_id: z.string(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const { trial_data_id, file_id } = req.input;

--- a/src/backend/routers/para.test.ts
+++ b/src/backend/routers/para.test.ts
@@ -57,13 +57,13 @@ test("createPara", async (t) => {
       .selectFrom("user")
       .where("first_name", "=", "Foo")
       .selectAll()
-      .executeTakeFirst()
+      .executeTakeFirst(),
   );
 
   t.true(
     nodemailerMock.mock
       .getSentMail()
-      .some((mail) => mail.subject?.includes("confirmation"))
+      .some((mail) => mail.subject?.includes("confirmation")),
   );
 });
 
@@ -105,7 +105,7 @@ test("createPara - invalid email", async (t) => {
       first_name: "Foo",
       last_name: "Bar",
       email: "invalid-email",
-    })
+    }),
   );
 });
 

--- a/src/backend/routers/para.ts
+++ b/src/backend/routers/para.ts
@@ -40,7 +40,7 @@ export const para = router({
         first_name: z.string(),
         last_name: z.string(),
         email: z.string().email(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const { email } = req.input;
@@ -49,9 +49,9 @@ export const para = router({
         req.input,
         req.ctx.db,
         req.ctx.auth.session.user?.name ?? "",
-        req.ctx.env.EMAIL,
+        req.ctx.env.EMAIL_FROM,
         email,
-        req.ctx.env
+        req.ctx.env,
       );
 
       return para;
@@ -90,7 +90,7 @@ export const para = router({
           .where("trial_data.created_by_user_id", "=", userId)
           .where("trial_data.submitted", "=", true)
           .select(({ fn }) =>
-            fn.count("trial_data.trial_data_id").as("completed_trials")
+            fn.count("trial_data.trial_data_id").as("completed_trials"),
           )
           .as("completed_trials"),
       ])

--- a/src/backend/routers/routes.test.ts
+++ b/src/backend/routers/routes.test.ts
@@ -76,7 +76,7 @@ test("All API endpoints are auth guarded", async (t) => {
         t.fail(
           `${fullProcedureName} threw an unexpected error: ${
             (error as Error).message
-          }`
+          }`,
         );
       }
     }

--- a/src/backend/routers/student.ts
+++ b/src/backend/routers/student.ts
@@ -44,7 +44,7 @@ export const student = router({
         student_id: z.string(),
         start_date: z.date(),
         end_date: z.date(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const { student_id, start_date, end_date } = req.input;
@@ -73,7 +73,7 @@ export const student = router({
         student_id: z.string(),
         start_date: z.date(),
         end_date: z.date(),
-      })
+      }),
     )
     .mutation(async (req) => {
       const { student_id, start_date, end_date } = req.input;
@@ -108,7 +108,7 @@ export const student = router({
     .input(
       z.object({
         student_id: z.string(),
-      })
+      }),
     )
     .query(async (req) => {
       const { student_id } = req.input;
@@ -134,7 +134,7 @@ export const student = router({
     .input(
       z.object({
         student_id: z.string().uuid(),
-      })
+      }),
     )
     .query(async (req) => {
       const { student_id } = req.input;

--- a/src/backend/scripts/run-with-gcp-metadata.ts
+++ b/src/backend/scripts/run-with-gcp-metadata.ts
@@ -18,7 +18,7 @@ const runWithGcpMetadata = async () => {
     const [projectId, regionPath, { access_token }]: [
       string,
       string,
-      { access_token: string }
+      { access_token: string },
     ] = await Promise.all([
       gcpMetadata.project("project-id"),
       gcpMetadata.instance("region"),
@@ -33,19 +33,19 @@ const runWithGcpMetadata = async () => {
         headers: {
           Authorization: `Bearer ${access_token}`,
         },
-      }
+      },
     );
 
     if (process.env.NEXTAUTH_URL && process.env.NEXTAUTH_URL !== "") {
       console.log(
-        "🕵️  NEXTAUTH_URL already set, NEXTAUTH_URL and BASE_HTTP_ENDPOINT will not be modified."
+        "🕵️  NEXTAUTH_URL already set, NEXTAUTH_URL and BASE_HTTP_ENDPOINT will not be modified.",
       );
     } else {
       env.NEXTAUTH_URL = getServiceResponse.data.status.url;
       env.BASE_HTTP_ENDPOINT = getServiceResponse.data.status.url;
 
       console.log(
-        "🕵️  running on GCP, environment will be modified with NEXTAUTH_URL and BASE_HTTP_ENDPOINT."
+        "🕵️  running on GCP, environment will be modified with NEXTAUTH_URL and BASE_HTTP_ENDPOINT.",
       );
     }
   } else {
@@ -53,7 +53,7 @@ const runWithGcpMetadata = async () => {
   }
 
   const splitArgsAt = process.argv.findIndex((arg) =>
-    arg.endsWith("run-with-gcp-metadata.ts")
+    arg.endsWith("run-with-gcp-metadata.ts"),
   );
   const args = process.argv.slice(splitArgsAt + 1);
 

--- a/src/backend/tests/fixtures/get-test-minio.ts
+++ b/src/backend/tests/fixtures/get-test-minio.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 const worker = registerSharedTypeScriptWorker({
   filename: path.join(
     path.dirname(fileURLToPath(import.meta.url)),
-    "./workers/get-test-minio.worker.ts"
+    "./workers/get-test-minio.worker.ts",
   ),
 });
 

--- a/src/backend/tests/fixtures/get-test-server.ts
+++ b/src/backend/tests/fixtures/get-test-server.ts
@@ -18,7 +18,7 @@ export interface GetTestServerOptions {
 
 export const getTestServer = async (
   t: ExecutionContext,
-  { authenticateAs }: GetTestServerOptions = {}
+  { authenticateAs }: GetTestServerOptions = {},
 ) => {
   const [
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -38,8 +38,12 @@ export const getTestServer = async (
     S3_USER_UPLOADS_ACCESS_KEY_ID: minio.accessKey,
     S3_USER_UPLOADS_SECRET_ACCESS_KEY: minio.secretKey,
     S3_USER_UPLOADS_BUCKET_NAME: minio.bucket,
-    EMAIL: "example string",
-    EMAIL_PASS: "example string",
+    EMAIL_SERVICE: "example string",
+    EMAIL_FROM: "example string",
+    EMAIL_AUTH_USER: "example string",
+    EMAIL_AUTH_PASS: "example string",
+    EMAIL_HOST: "example string",
+    EMAIL_PORT: "example string",
   };
 
   // Use statically-built Next.js fixture (if multiple instances of the built-in next() dev server are running, they try to concurrently mutate the same files).

--- a/src/backend/tests/fixtures/workers/get-test-minio.worker.ts
+++ b/src/backend/tests/fixtures/workers/get-test-minio.worker.ts
@@ -5,7 +5,7 @@ import { CreateBucketCommand } from "@aws-sdk/client-s3";
 
 const startMinio = async () => {
   const container = await new GenericContainer(
-    "minio/minio:RELEASE.2023-05-18T00-05-36Z"
+    "minio/minio:RELEASE.2023-05-18T00-05-36Z",
   )
     .withExposedPorts(9000)
     .withCommand(["server", "/data"])

--- a/src/components/benchmarks/BenchmarkAssignmentModal.tsx
+++ b/src/components/benchmarks/BenchmarkAssignmentModal.tsx
@@ -41,7 +41,7 @@ const STEPS = ["PARA_SELECTION", "DURATION_SELECTION"];
 type Step = (typeof STEPS)[number];
 
 export const BenchmarkAssignmentModal = (
-  props: BenchmarkAssignmentModalProps
+  props: BenchmarkAssignmentModalProps,
 ) => {
   const [selectedParaIds, setSelectedParaIds] = useState<string[]>([]);
   const nextButtonRef = useRef<HTMLButtonElement>(null);

--- a/src/components/benchmarks/BenchmarksContainer.tsx
+++ b/src/components/benchmarks/BenchmarksContainer.tsx
@@ -60,7 +60,7 @@ export default function BenchmarksContainer({
 }) {
   const router = useRouter();
   const [activeTab, setActiveTab] = useState<selectableTabs>(
-    selectableTabs.ALL
+    selectableTabs.ALL,
   );
   return (
     <Stack sx={{ width: 1 }}>
@@ -111,7 +111,7 @@ export default function BenchmarksContainer({
           {(() => {
             const { status, message } = tabMapping[activeTab];
             const filteredBenchmarks = benchmarks.filter((benchmark) =>
-              status === "All" ? true : benchmark.status === status
+              status === "All" ? true : benchmark.status === status,
             );
 
             return filteredBenchmarks.length === 0 ? (

--- a/src/components/benchmarks/Duration-Selection-Step.tsx
+++ b/src/components/benchmarks/Duration-Selection-Step.tsx
@@ -33,7 +33,7 @@ export const DurationSelectionStep = ({
   onDurationChange,
 }: DurationSelectionStepProps) => {
   const handleTypeChange = (
-    event: SelectChangeEvent<AssignmentDuration["type"]>
+    event: SelectChangeEvent<AssignmentDuration["type"]>,
   ) => {
     switch (event.target.value) {
       case "forever":

--- a/src/components/design_system/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/design_system/breadcrumbs/Breadcrumbs.tsx
@@ -16,11 +16,11 @@ const BreadcrumbsNav = () => {
   // Only 1 of these will run at a time based on the conditions
   const { data: student } = trpc.student.getStudentById.useQuery(
     { student_id: paths[2] },
-    { enabled: Boolean(paths[2] && paths[1] === "students") }
+    { enabled: Boolean(paths[2] && paths[1] === "students") },
   );
   const { data: para } = trpc.para.getParaById.useQuery(
     { user_id: paths[2] },
-    { enabled: Boolean(paths[2] && paths[1] === "staff") }
+    { enabled: Boolean(paths[2] && paths[1] === "staff") },
   );
 
   const personData: Student | Para | undefined = student || para;

--- a/src/components/design_system/button/Button.module.css
+++ b/src/components/design_system/button/Button.module.css
@@ -18,7 +18,8 @@
 }
 
 .default:hover {
-  box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.3),
+  box-shadow:
+    0px 1px 2px 0px rgba(0, 0, 0, 0.3),
     0px 1px 3px 1px rgba(0, 0, 0, 0.15);
   background-color: var(--primary-50);
 }

--- a/src/components/iep/Iep.tsx
+++ b/src/components/iep/Iep.tsx
@@ -25,7 +25,7 @@ const Iep = ({ iep_id }: IepProps) => {
 
   const { data: goals, isLoading } = trpc.iep.getGoals.useQuery(
     { iep_id: iep_id },
-    { enabled: Boolean(iep_id) }
+    { enabled: Boolean(iep_id) },
   );
 
   const router = useRouter();

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -42,7 +42,7 @@ export interface ParaHeadCell extends HeadCell {
 }
 
 export function isStudentWithIep(
-  person: StudentWithIep | Para
+  person: StudentWithIep | Para,
 ): person is StudentWithIep {
   return (
     (person as StudentWithIep).student_id !== undefined &&
@@ -64,7 +64,7 @@ type Order = "asc" | "desc";
 
 function getComparator<T>(
   order: Order,
-  orderBy: keyof T
+  orderBy: keyof T,
 ): (a: T, b: T) => number {
   return order === "desc"
     ? (a, b) => descendingComparator(a, b, orderBy)
@@ -264,7 +264,7 @@ interface EnhancedTableProps<Person, Column> {
  */
 export default function EnhancedTable<
   Person extends StudentWithIep | Para,
-  Column extends HeadCell
+  Column extends HeadCell,
 >({ people, onSubmit, headCells, type }: EnhancedTableProps<Person, Column>) {
   const router = useRouter();
 
@@ -287,7 +287,7 @@ export default function EnhancedTable<
 
   const handleRequestSort = (
     event: React.MouseEvent<unknown>,
-    property: string
+    property: string,
   ) => {
     const isAsc = orderBy === property && order === "asc";
     setOrder(isAsc ? "desc" : "asc");
@@ -314,7 +314,7 @@ export default function EnhancedTable<
 
       return filteredList;
     },
-    [headCells]
+    [headCells],
   );
 
   const visibleRows = useMemo(() => {
@@ -390,7 +390,7 @@ export default function EnhancedTable<
                       handleLinkToPage(
                         isStudentWithIep(row)
                           ? `../students/${row.student_id || ""}`
-                          : `../staff/${row.user_id || ""}`
+                          : `../staff/${row.user_id || ""}`,
                       )
                     }
                   >

--- a/src/components/taskCard/taskCard.tsx
+++ b/src/components/taskCard/taskCard.tsx
@@ -28,7 +28,7 @@ const TaskCard = ({ task, isPara }: TaskCardProps) => {
   const completionRate = useMemo(() => {
     const num = parseInt(task.completed_trials as string) || 0;
     const calculatedRate = Math.floor(
-      (num / (task.number_of_trials ?? 1)) * 100
+      (num / (task.number_of_trials ?? 1)) * 100,
     );
     return calculatedRate;
   }, [task.completed_trials, task.number_of_trials]);
@@ -56,10 +56,10 @@ const TaskCard = ({ task, isPara }: TaskCardProps) => {
         {!task.seen
           ? "NEW"
           : completionRate >= 100
-          ? "DONE"
-          : `DUE: ${
-              task.due_date ? format(task.due_date, "MM-dd-yyyy") : "N/A"
-            }`}
+            ? "DONE"
+            : `DUE: ${
+                task.due_date ? format(task.due_date, "MM-dd-yyyy") : "N/A"
+              }`}
       </div>
       <div className={$taskCard.profile}>
         {task.first_name} {task.last_name}

--- a/src/components/timer/timer.tsx
+++ b/src/components/timer/timer.tsx
@@ -16,7 +16,7 @@ const Timer = ({ timeInSec }: TimerProps) => {
       dateTimeObject.setSeconds(dateTimeObject.getSeconds() + inputTime);
       restart(dateTimeObject, false);
     },
-    [restart]
+    [restart],
   );
 
   useEffect(() => {

--- a/src/hooks/useConfirmBeforeLeave.tsx
+++ b/src/hooks/useConfirmBeforeLeave.tsx
@@ -4,7 +4,7 @@ import { useBeforeUnload } from "react-use";
 
 const useConfirmBeforeLeave = (
   isConfirm: boolean | (() => boolean) = false,
-  message = "Are you sure you want to leave? You have unsaved changes."
+  message = "Are you sure you want to leave? You have unsaved changes.",
 ) => {
   useBeforeUnload(isConfirm, message);
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -56,7 +56,7 @@ export default function App({
             }
           },
         }),
-      })
+      }),
   );
 
   const [trpcClient] = useState(() =>
@@ -74,7 +74,7 @@ export default function App({
           url: `${getBaseUrl()}/api/trpc`,
         }),
       ],
-    })
+    }),
   );
 
   return (

--- a/src/pages/api/hello.ts
+++ b/src/pages/api/hello.ts
@@ -7,7 +7,7 @@ type Data = {
 
 export default function handler(
   req: NextApiRequest,
-  res: NextApiResponse<Data>
+  res: NextApiResponse<Data>,
 ) {
   res.status(200).json({ name: "John Doe" });
 }

--- a/src/pages/benchmarks/[benchmark_id]/index.tsx
+++ b/src/pages/benchmarks/[benchmark_id]/index.tsx
@@ -39,7 +39,7 @@ const BenchmarkPage = () => {
     },
     {
       enabled: Boolean(benchmark_id),
-    }
+    },
   );
   const seenMutation = trpc.iep.markAsSeen.useMutation({
     onSuccess: async () => await utils.iep.getSubgoalAndTrialData.invalidate(),
@@ -148,7 +148,7 @@ const BenchmarkPage = () => {
       }
     },
     1000,
-    [notesInputValue, successInputValue, unsuccessInputValue]
+    [notesInputValue, successInputValue, unsuccessInputValue],
   );
 
   // BUG?: Sometimes if the user reloads/navigates away and confirms, the update has time to go through and data is saved. Is this something we should fix?
@@ -270,8 +270,8 @@ const BenchmarkPage = () => {
         {hasInputChanged || updateTrialMutation.isLoading
           ? "Saving..."
           : updateTrialMutation.isError
-          ? "uh oh"
-          : "Saved to Cloud"}
+            ? "uh oh"
+            : "Saved to Cloud"}
       </div>
 
       <Grid container spacing={2}>

--- a/src/pages/benchmarks/[benchmark_id]/instructions.tsx
+++ b/src/pages/benchmarks/[benchmark_id]/instructions.tsx
@@ -12,7 +12,7 @@ const InstructionsPage = () => {
   const { benchmark_id } = router.query;
   const { data: subgoal, isLoading } = trpc.iep.getSubgoalAndTrialData.useQuery(
     { task_id: benchmark_id as string },
-    { enabled: Boolean(benchmark_id) }
+    { enabled: Boolean(benchmark_id) },
   );
 
   if (isLoading || !subgoal) {

--- a/src/pages/benchmarks/[benchmark_id]/review.tsx
+++ b/src/pages/benchmarks/[benchmark_id]/review.tsx
@@ -13,7 +13,7 @@ const ReviewPage = () => {
     },
     {
       enabled: Boolean(benchmark_id),
-    }
+    },
   );
 
   const updateTrialMutation = trpc.iep.updateTrialData.useMutation();

--- a/src/pages/benchmarks/[benchmark_id]/studentprofile.tsx
+++ b/src/pages/benchmarks/[benchmark_id]/studentprofile.tsx
@@ -13,7 +13,7 @@ const StudentProfilePage = () => {
   const { benchmark_id } = router.query;
   const { data: student, isLoading } = trpc.student.getStudentByTaskId.useQuery(
     { task_id: benchmark_id as string },
-    { enabled: Boolean(benchmark_id) }
+    { enabled: Boolean(benchmark_id) },
   );
 
   if (!student || isLoading) {

--- a/src/pages/benchmarks/index.tsx
+++ b/src/pages/benchmarks/index.tsx
@@ -108,7 +108,7 @@ function Benchmarks() {
           <Box sx={{ height: "75vh", overflowY: "scroll" }}>
             {tasks?.map((task) => {
               const completed = Math.floor(
-                Number(task.completed_trials) / Number(task.number_of_trials)
+                Number(task.completed_trials) / Number(task.number_of_trials),
               );
               return (
                 <div key={task.task_id} className={$typo.noDecoration}>

--- a/src/pages/files.tsx
+++ b/src/pages/files.tsx
@@ -12,7 +12,7 @@ const FilesPage = () => {
     event.preventDefault();
 
     const fileInput = event.currentTarget.elements.namedItem(
-      "file"
+      "file",
     ) as HTMLInputElement;
     if (!fileInput.files) return;
 

--- a/src/pages/staff/[user_id].tsx
+++ b/src/pages/staff/[user_id].tsx
@@ -36,7 +36,7 @@ const ViewParaPage = () => {
       enabled: Boolean(user_id),
       retry: false,
       onError: () => returnToStaffList(),
-    }
+    },
   );
 
   const editMutation = trpc.case_manager.editPara.useMutation({

--- a/src/pages/students/[student_id].tsx
+++ b/src/pages/students/[student_id].tsx
@@ -50,7 +50,7 @@ const ViewStudentPage = () => {
       enabled: Boolean(student_id),
       retry: false,
       onError: () => returnToStudentList(),
-    }
+    },
   );
 
   const returnToStudentList = async () => {
@@ -59,7 +59,7 @@ const ViewStudentPage = () => {
 
   const { data: activeIep } = trpc.student.getActiveStudentIep.useQuery(
     { student_id: student_id as string },
-    { enabled: Boolean(student_id), retry: false }
+    { enabled: Boolean(student_id), retry: false },
   );
 
   const editMutation = trpc.case_manager.editStudent.useMutation({

--- a/src/pages/students/[student_id]/goals/[goal_id].tsx
+++ b/src/pages/students/[student_id]/goals/[goal_id].tsx
@@ -12,7 +12,7 @@ const GoalPage = () => {
 
   const { data: activeIep } = trpc.student.getActiveStudentIep.useQuery(
     { student_id: student_id },
-    { enabled: Boolean(student_id), retry: false }
+    { enabled: Boolean(student_id), retry: false },
   );
   const { data: goals = [] } = trpc.iep.getGoals.useQuery({
     iep_id: activeIep?.iep_id || "",
@@ -20,12 +20,12 @@ const GoalPage = () => {
 
   const { data: goal } = trpc.iep.getGoal.useQuery(
     { goal_id: goal_id },
-    { enabled: Boolean(goal_id) }
+    { enabled: Boolean(goal_id) },
   );
 
   const { data: benchmarks } = trpc.iep.getSubgoals.useQuery(
     { goal_id: goal_id },
-    { enabled: Boolean(goal_id) }
+    { enabled: Boolean(goal_id) },
   );
 
   const goal_index = goals.findIndex((g) => g.goal_id === goal?.goal_id) + 1;

--- a/src/pages/students/[student_id]/goals/[goal_id]/create.tsx
+++ b/src/pages/students/[student_id]/goals/[goal_id]/create.tsx
@@ -42,7 +42,7 @@ const CreateBenchmarkPage = () => {
   const router = useRouter();
   const { data: goal } = trpc.iep.getGoal.useQuery(
     { goal_id: router.query.goal_id as string },
-    { enabled: Boolean(router.query.goal_id) }
+    { enabled: Boolean(router.query.goal_id) },
   );
 
   const addSubgoalMutation = trpc.iep.addSubgoal.useMutation();
@@ -121,7 +121,7 @@ const CreateBenchmarkPage = () => {
       await router.push(
         `/students/${router.query.student_id as string}/goals/${
           router.query.goal_id as string
-        }`
+        }`,
       );
     } catch (error) {
       console.error("Error creating benchmark", error);

--- a/src/pages/students/index.tsx
+++ b/src/pages/students/index.tsx
@@ -33,7 +33,7 @@ const Students = () => {
         }
       } catch {
         alert(
-          `This student is already assigned to a case manager. Please check your roster if the student is already there. Otherwise, this student is with another case manager.`
+          `This student is already assigned to a case manager. Please check your roster if the student is already there. Otherwise, this student is with another case manager.`,
         );
       }
     },

--- a/supporting_services/docker-compose.yml
+++ b/supporting_services/docker-compose.yml
@@ -11,6 +11,12 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 
+  mailcatcher:
+    image: dockage/mailcatcher:0.9.0
+    ports:
+      - "1025:1025"
+      - "1080:1080"
+
   minio:
     image: minio/minio:RELEASE.2023-05-18T00-05-36Z
     ports:


### PR DESCRIPTION
IMPORTANT: the environment variable `EMAIL` has been renamed to `EMAIL_FROM` and `EMAIL_PASS` to `EMAIL_AUTH_PASS`. These will have to be changed in your `.env` file manually. To test this branch, copy the new example EMAIL_* vars into your `.env` file. Keep a copy of your old vars if you want to switch back.

If you use the new default EMAIL_* vars in `.env.example` it will send to Mailcatcher on port 1025 running in Docker.

You can then view the emails in the Mailcatcher interface on port 1080, i.e. http://localhost:1080

It looks like this:

<img width="1840" alt="Screenshot 2024-10-10 at 5 22 26 PM" src="https://github.com/user-attachments/assets/0d9bb972-f15a-44b8-93c9-98a417c6753f">
