### PR TITLE
Attempt to fix intermittent prettier issues

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,7 +31,9 @@ jobs:
       - name: Install dependencies
         run: npm i --ci
       - name: Run format:check
-        run: npm run format:check
+        run: |
+          npm run format:version
+          npm run format:check
       - name: Run lint
         run: npm run lint
 

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,1 +1,4 @@
-{}
+{
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,5 @@
 {
   "tabWidth": 2,
-  "useTabs": false
+  "useTabs": false,
+  "trailingComma": "es5"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "lint-staged": "^13.1.0",
         "nextjs-server-modules": "^4.7.0",
         "nodemailer-mock": "^2.0.1",
-        "prettier": "^2.8.8",
+        "prettier": "^3.3.3",
         "rewiremock": "^3.14.5",
         "storybook": "^8.1.11",
         "testcontainers": "^9.8.0",
@@ -6301,21 +6301,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@storybook/codemod/node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@storybook/codemod/node_modules/slash": {
@@ -19594,14 +19579,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
-      "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -21797,21 +21783,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/storybook/node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/storybook/node_modules/slash": {
@@ -29084,12 +29055,6 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
           "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
-          "dev": true
-        },
-        "prettier": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-          "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
           "dev": true
         },
         "slash": {
@@ -37760,7 +37725,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.8",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true
     },
     "prettier-fallback": {
@@ -39248,12 +39215,6 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
           "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
-          "dev": true
-        },
-        "prettier": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-          "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
           "dev": true
         },
         "slash": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "postinstall": "next build --no-lint && nsm build --skip-build --only-api-files && npm run type-css",
     "format": "prettier --write --ignore-unknown .",
     "format:check": "prettier --check --ignore-unknown .",
+    "format:version": "prettier --version",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "all:check": "npm run type:check && npm run type-css:check && npm run lint && npm run format:check && npm run test",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "lint-staged": "^13.1.0",
     "nextjs-server-modules": "^4.7.0",
     "nodemailer-mock": "^2.0.1",
-    "prettier": "^2.8.8",
+    "prettier": "^3.3.3",
     "rewiremock": "^3.14.5",
     "storybook": "^8.1.11",
     "testcontainers": "^9.8.0",

--- a/src/backend/scripts/run-with-gcp-metadata.ts
+++ b/src/backend/scripts/run-with-gcp-metadata.ts
@@ -18,7 +18,7 @@ const runWithGcpMetadata = async () => {
     const [projectId, regionPath, { access_token }]: [
       string,
       string,
-      { access_token: string }
+      { access_token: string },
     ] = await Promise.all([
       gcpMetadata.project("project-id"),
       gcpMetadata.instance("region"),

--- a/src/components/design_system/button/Button.module.css
+++ b/src/components/design_system/button/Button.module.css
@@ -18,7 +18,8 @@
 }
 
 .default:hover {
-  box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.3),
+  box-shadow:
+    0px 1px 2px 0px rgba(0, 0, 0, 0.3),
     0px 1px 3px 1px rgba(0, 0, 0, 0.15);
   background-color: var(--primary-50);
 }

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -264,7 +264,7 @@ interface EnhancedTableProps<Person, Column> {
  */
 export default function EnhancedTable<
   Person extends StudentWithIep | Para,
-  Column extends HeadCell
+  Column extends HeadCell,
 >({ people, onSubmit, headCells, type }: EnhancedTableProps<Person, Column>) {
   const router = useRouter();
 

--- a/src/components/taskCard/taskCard.tsx
+++ b/src/components/taskCard/taskCard.tsx
@@ -56,10 +56,10 @@ const TaskCard = ({ task, isPara }: TaskCardProps) => {
         {!task.seen
           ? "NEW"
           : completionRate >= 100
-          ? "DONE"
-          : `DUE: ${
-              task.due_date ? format(task.due_date, "MM-dd-yyyy") : "N/A"
-            }`}
+            ? "DONE"
+            : `DUE: ${
+                task.due_date ? format(task.due_date, "MM-dd-yyyy") : "N/A"
+              }`}
       </div>
       <div className={$taskCard.profile}>
         {task.first_name} {task.last_name}

--- a/src/pages/benchmarks/[benchmark_id]/index.tsx
+++ b/src/pages/benchmarks/[benchmark_id]/index.tsx
@@ -270,8 +270,8 @@ const BenchmarkPage = () => {
         {hasInputChanged || updateTrialMutation.isLoading
           ? "Saving..."
           : updateTrialMutation.isError
-          ? "uh oh"
-          : "Saved to Cloud"}
+            ? "uh oh"
+            : "Saved to Cloud"}
       </div>
 
       <Grid container spacing={2}>


### PR DESCRIPTION
We've historically had issues with prettier failing in the build pipeline for unknown reasons. This is likely some kind of versioning issue. Examining outputs of running v2.8.8 vs v.3.3.3 confirms different output, which can account for the issue as described in #437. However, we still don't know why the issue is intermittent nor why it sometimes seems to differ between environments. Forcing all versions of prettier to be v.3 or above and our code to conform to its defaults/our config is the goal of this PR.

This PR does the following:
- merges two prettier config files into one
- adds config property `trailingComma: "es5"` to preserve as much formatting as possible when going from v2 (where it's the default) and v3 (where `trailingComma: "all"` is the default instead)
- upgrades prettier from v2.8.8 to v.3.3.3 (latest)
- adds debugging statement in Github build pipeline to print out the prettier version for comparison between local and Github, which may be useful when there's an actual conflict in output (intermittent issue) and the build fails like in #437
- one-time formats a handful of files to address breaking changes in prettier v.3