### PR TITLE
Feat: add uniqueness constraint to task table

### DIFF
--- a/src/backend/db/migrations/2_add-uniqueness-constraint-on-tasks.sql
+++ b/src/backend/db/migrations/2_add-uniqueness-constraint-on-tasks.sql
@@ -1,0 +1,7 @@
+-- Each task should have a unique subgoal_id - assignee_id combination
+-- which corresponds to a unique benchmark / para combo
+ALTER TABLE task
+ADD CONSTRAINT UC_Task UNIQUE (subgoal_id, assignee_id);
+
+-- Add index to allow easy queries of tasks by assignee
+CREATE INDEX idx_task_assignee ON task(assignee_id);

--- a/src/backend/db/migrations/2_add-uniqueness-constraint-on-tasks.sql
+++ b/src/backend/db/migrations/2_add-uniqueness-constraint-on-tasks.sql
@@ -1,7 +1,7 @@
 -- Each task should have a unique subgoal_id - assignee_id combination
 -- which corresponds to a unique benchmark / para combo
 ALTER TABLE task
-ADD CONSTRAINT UC_Task UNIQUE (subgoal_id, assignee_id);
+ADD CONSTRAINT subgoal_assignee_unique UNIQUE (subgoal_id, assignee_id);
 
 -- Add index to allow easy queries of tasks by assignee
 CREATE INDEX idx_task_assignee ON task(assignee_id);

--- a/src/backend/db/zapatos/schema.d.ts
+++ b/src/backend/db/zapatos/schema.d.ts
@@ -2165,7 +2165,7 @@ declare module 'zapatos/schema' {
       */
       seen?: boolean | db.Parameter<boolean> | db.DefaultType | db.SQLFragment | db.SQLFragment<any, boolean | db.Parameter<boolean> | db.DefaultType | db.SQLFragment>;
     }
-    export type UniqueIndex = 'task_pkey' | 'uc_task';
+    export type UniqueIndex = 'subgoal_assignee_unique' | 'task_pkey';
     export type Column = keyof Selectable;
     export type OnlyCols<T extends readonly Column[]> = Pick<Selectable, T[number]>;
     export type SQLExpression = Table | db.ColumnNames<Updatable | (keyof Updatable)[]> | db.ColumnValues<Updatable> | Whereable | Column | db.ParentColumn | db.GenericSQLExpression;

--- a/src/backend/db/zapatos/schema.d.ts
+++ b/src/backend/db/zapatos/schema.d.ts
@@ -2165,7 +2165,7 @@ declare module 'zapatos/schema' {
       */
       seen?: boolean | db.Parameter<boolean> | db.DefaultType | db.SQLFragment | db.SQLFragment<any, boolean | db.Parameter<boolean> | db.DefaultType | db.SQLFragment>;
     }
-    export type UniqueIndex = 'task_pkey';
+    export type UniqueIndex = 'task_pkey' | 'uc_task';
     export type Column = keyof Selectable;
     export type OnlyCols<T extends readonly Column[]> = Pick<Selectable, T[number]>;
     export type SQLExpression = Table | db.ColumnNames<Updatable | (keyof Updatable)[]> | db.ColumnValues<Updatable> | Whereable | Column | db.ParentColumn | db.GenericSQLExpression;

--- a/src/backend/lib/db_helpers/case_manager.ts
+++ b/src/backend/lib/db_helpers/case_manager.ts
@@ -21,7 +21,7 @@ export async function createPara(
   from_email: string,
   to_email: string,
   env: Env
-): Promise<user.Selectable | undefined> {
+): Promise<user.Selectable> {
   const { first_name, last_name, email } = para;
 
   let paraData = await db
@@ -40,7 +40,7 @@ export async function createPara(
         role: "staff",
       })
       .returningAll()
-      .executeTakeFirst();
+      .executeTakeFirstOrThrow();
 
     // promise, will not interfere with returning paraData
     void sendInviteEmail(

--- a/src/backend/routers/case_manager.ts
+++ b/src/backend/routers/case_manager.ts
@@ -171,7 +171,7 @@ export const case_manager = router({
       );
 
       return await assignParaToCaseManager(
-        para?.user_id || "",
+        para.user_id,
         req.ctx.auth.userId,
         req.ctx.db
       );

--- a/src/backend/routers/iep.test.ts
+++ b/src/backend/routers/iep.test.ts
@@ -164,7 +164,13 @@ test("assignTaskToParas - no duplicate subgoal_id + para_id combo", async (t) =>
     authenticateAs: "case_manager",
   });
 
-  const para_id = seed.para.user_id;
+  const para_1 = seed.para;
+
+  const para_2 = await trpc.para.createPara.mutate({
+    first_name: "Foo",
+    last_name: "Bar",
+    email: "foo.bar@email.com",
+  });
 
   const iep = await trpc.student.addIep.mutate({
     student_id: seed.student.student_id,
@@ -195,7 +201,7 @@ test("assignTaskToParas - no duplicate subgoal_id + para_id combo", async (t) =>
 
   await trpc.iep.assignTaskToParas.mutate({
     subgoal_id: subgoal1Id,
-    para_ids: [para_id],
+    para_ids: [para_1.user_id],
     due_date: new Date("2023-12-31"),
     trial_count: 5,
   });
@@ -203,7 +209,7 @@ test("assignTaskToParas - no duplicate subgoal_id + para_id combo", async (t) =>
   const error = await t.throwsAsync(async () => {
     await trpc.iep.assignTaskToParas.mutate({
       subgoal_id: subgoal1Id,
-      para_ids: [para_id],
+      para_ids: [para_1.user_id, para_2.user_id],
       due_date: new Date("2024-03-31"),
       trial_count: 1,
     });

--- a/src/backend/routers/iep.test.ts
+++ b/src/backend/routers/iep.test.ts
@@ -155,7 +155,7 @@ test("addTask - no duplicate subgoal_id + assigned_id combo", async (t) => {
 
   t.is(
     error?.message,
-    'duplicate key value violates unique constraint "uc_task"'
+    "Task already exists: This subgoal has already been assigned to the same para"
   );
 });
 

--- a/src/backend/routers/iep.test.ts
+++ b/src/backend/routers/iep.test.ts
@@ -211,7 +211,7 @@ test("assignTaskToParas - no duplicate subgoal_id + para_id combo", async (t) =>
 
   t.is(
     error?.message,
-    "Task already exists: This subgoal has already been assigned to the same para"
+    "Task already exists: This subgoal has already been assigned to one or more of these paras"
   );
 });
 

--- a/src/backend/routers/iep.test.ts
+++ b/src/backend/routers/iep.test.ts
@@ -35,6 +35,21 @@ test("basic flow - add/get goals, subgoals, tasks", async (t) => {
     number_of_trials: 15,
   });
 
+  const subgoal1 = await trpc.iep.addSubgoal.mutate({
+    goal_id: goal1!.goal_id,
+    status: "Complete",
+    description: "subgoal 1",
+    setup: "",
+    instructions: "",
+    materials: "materials",
+    target_level: 100,
+    baseline_level: 20,
+    metric_name: "words",
+    attempts_per_trial: 10,
+    number_of_trials: 30,
+  });
+  const subgoal1Id = subgoal1!.subgoal_id;
+
   const subgoal2 = await trpc.iep.addSubgoal.mutate({
     goal_id: goal1!.goal_id,
     status: "Complete",
@@ -51,7 +66,7 @@ test("basic flow - add/get goals, subgoals, tasks", async (t) => {
   const subgoal2Id = subgoal2!.subgoal_id;
 
   await trpc.iep.addTask.mutate({
-    subgoal_id: subgoal2Id,
+    subgoal_id: subgoal1Id,
     assignee_id: para_id,
     due_date: new Date("2023-12-31"),
     trial_count: 5,
@@ -70,7 +85,7 @@ test("basic flow - add/get goals, subgoals, tasks", async (t) => {
   const gotSubgoals = await trpc.iep.getSubgoals.query({
     goal_id: goal1!.goal_id,
   });
-  t.is(gotSubgoals.length, 2);
+  t.is(gotSubgoals.length, 3);
 
   const gotSubgoal = await trpc.iep.getSubgoal.query({
     subgoal_id: subgoal2Id,
@@ -85,6 +100,62 @@ test("basic flow - add/get goals, subgoals, tasks", async (t) => {
       .where("assignee_id", "=", para_id)
       .selectAll()
       .executeTakeFirstOrThrow()
+  );
+});
+
+test("addTask - no duplicate subgoal_id + assigned_id combo", async (t) => {
+  const { trpc, seed } = await getTestServer(t, {
+    authenticateAs: "case_manager",
+  });
+
+  const para_id = seed.para.user_id;
+
+  const iep = await trpc.student.addIep.mutate({
+    student_id: seed.student.student_id,
+    start_date: new Date("2023-01-01"),
+    end_date: new Date("2023-12-31"),
+  });
+
+  const goal1 = await trpc.iep.addGoal.mutate({
+    iep_id: iep.iep_id,
+    description: "goal 1",
+    category: "writing",
+  });
+
+  const subgoal1 = await trpc.iep.addSubgoal.mutate({
+    goal_id: goal1!.goal_id,
+    status: "Complete",
+    description: "subgoal 1",
+    setup: "",
+    instructions: "",
+    materials: "materials",
+    target_level: 100,
+    baseline_level: 20,
+    metric_name: "words",
+    attempts_per_trial: 10,
+    number_of_trials: 30,
+  });
+  const subgoal1Id = subgoal1!.subgoal_id;
+
+  await trpc.iep.addTask.mutate({
+    subgoal_id: subgoal1Id,
+    assignee_id: para_id,
+    due_date: new Date("2023-12-31"),
+    trial_count: 5,
+  });
+
+  const error = await t.throwsAsync(async () => {
+    await trpc.iep.addTask.mutate({
+      subgoal_id: subgoal1Id,
+      assignee_id: para_id,
+      due_date: new Date("2024-03-31"),
+      trial_count: 1,
+    });
+  });
+
+  t.is(
+    error?.message,
+    'duplicate key value violates unique constraint "uc_task"'
   );
 });
 

--- a/src/backend/routers/iep.ts
+++ b/src/backend/routers/iep.ts
@@ -135,6 +135,20 @@ export const iep = router({
     .mutation(async (req) => {
       const { subgoal_id, assignee_id, due_date, trial_count } = req.input;
 
+      // make sure that this goal belongs to this case manager
+      const existingTask = await req.ctx.db
+        .selectFrom("task")
+        .where("subgoal_id", "=", subgoal_id)
+        .where("assignee_id", "=", assignee_id)
+        .selectAll()
+        .executeTakeFirst();
+
+      if (existingTask) {
+        throw new Error(
+          "Task already exists: This subgoal has already been assigned to the same para"
+        );
+      }
+
       const result = await req.ctx.db
         .insertInto("task")
         .values({

--- a/src/backend/routers/iep.ts
+++ b/src/backend/routers/iep.ts
@@ -176,7 +176,7 @@ export const iep = router({
       const existingTasks = await req.ctx.db
         .selectFrom("task")
         .where("subgoal_id", "=", subgoal_id)
-        .where("assignee_id", "=", para_ids)
+        .where("assignee_id", "in", para_ids)
         .selectAll()
         .execute();
 

--- a/src/backend/routers/iep.ts
+++ b/src/backend/routers/iep.ts
@@ -182,7 +182,7 @@ export const iep = router({
 
       if (existingTasks.length > 0) {
         throw new Error(
-          "Task already exists: This subgoal has already been assigned to the same para"
+          "Task already exists: This subgoal has already been assigned to one or more of these paras"
         );
       }
 

--- a/src/backend/routers/iep.ts
+++ b/src/backend/routers/iep.ts
@@ -173,6 +173,19 @@ export const iep = router({
     .mutation(async (req) => {
       const { subgoal_id, para_ids, due_date, trial_count } = req.input;
 
+      const existingTasks = await req.ctx.db
+        .selectFrom("task")
+        .where("subgoal_id", "=", subgoal_id)
+        .where("assignee_id", "=", para_ids)
+        .selectAll()
+        .execute();
+
+      if (existingTasks.length > 0) {
+        throw new Error(
+          "Task already exists: This subgoal has already been assigned to the same para"
+        );
+      }
+
       const result = await req.ctx.db
         .insertInto("task")
         .values(

--- a/src/backend/routers/iep.ts
+++ b/src/backend/routers/iep.ts
@@ -135,7 +135,6 @@ export const iep = router({
     .mutation(async (req) => {
       const { subgoal_id, assignee_id, due_date, trial_count } = req.input;
 
-      // make sure that this goal belongs to this case manager
       const existingTask = await req.ctx.db
         .selectFrom("task")
         .where("subgoal_id", "=", subgoal_id)

--- a/src/components/benchmarks/BenchmarkAssignmentModal.tsx
+++ b/src/components/benchmarks/BenchmarkAssignmentModal.tsx
@@ -111,7 +111,9 @@ export const BenchmarkAssignmentModal = (
       } catch (err) {
         // TODO: issue #450
         console.log(err);
-        setErrorMessage(err.message as string);
+        if (err instanceof Error) {
+          setErrorMessage(err.message);
+        }
       }
     }
   };

--- a/src/components/benchmarks/BenchmarkAssignmentModal.tsx
+++ b/src/components/benchmarks/BenchmarkAssignmentModal.tsx
@@ -54,9 +54,12 @@ export const BenchmarkAssignmentModal = (
     subgoal_id: props.benchmark_id,
   });
 
+  const [errorMessage, setErrorMessage] = useState<string>("");
+
   const assignTaskToPara = trpc.iep.assignTaskToParas.useMutation();
 
   const handleParaToggle = (paraId: string) => () => {
+    setErrorMessage("");
     setSelectedParaIds((prev) => {
       if (prev.includes(paraId)) {
         return prev.filter((id) => id !== paraId);
@@ -69,6 +72,7 @@ export const BenchmarkAssignmentModal = (
   const handleClose = () => {
     props.onClose();
     setSelectedParaIds([]);
+    setErrorMessage("");
     setCurrentModalSelection("PARA_SELECTION");
   };
 
@@ -90,19 +94,25 @@ export const BenchmarkAssignmentModal = (
       setCurrentModalSelection(nextStep);
     } else {
       // Reached end, save
-      await assignTaskToPara.mutateAsync({
-        subgoal_id: props.benchmark_id,
-        para_ids: selectedParaIds,
-        due_date:
-          assignmentDuration.type === "until_date"
-            ? assignmentDuration.date
-            : undefined,
-        trial_count:
-          assignmentDuration.type === "minimum_number_of_collections"
-            ? assignmentDuration.minimumNumberOfCollections
-            : undefined,
-      });
-      handleClose();
+      try {
+        await assignTaskToPara.mutateAsync({
+          subgoal_id: props.benchmark_id,
+          para_ids: selectedParaIds,
+          due_date:
+            assignmentDuration.type === "until_date"
+              ? assignmentDuration.date
+              : undefined,
+          trial_count:
+            assignmentDuration.type === "minimum_number_of_collections"
+              ? assignmentDuration.minimumNumberOfCollections
+              : undefined,
+        });
+        handleClose();
+      } catch (err) {
+        // TODO: issue #450
+        console.log(err);
+        setErrorMessage(err.message as string);
+      }
     }
   };
 
@@ -171,6 +181,12 @@ export const BenchmarkAssignmentModal = (
               onDurationChange={setAssignmentDuration}
               disabled={assignTaskToPara.isLoading}
             />
+          </Box>
+        )}
+
+        {errorMessage && (
+          <Box className={$benchmark.benchmarkDescriptionBox}>
+            {errorMessage}
           </Box>
         )}
         <DialogActions>


### PR DESCRIPTION
Closes #439

Add uniqueness constraint on tasks to prevent assigning the same
benchmark (subgoal) to the same para (assignee).

What remains to be done is #450 , the frontend should indicate that a task has already been assigned to a given assignee and not allow the option to assign it to them again.
