### PR TITLE
Fixes #468 (extra trial data) - update to prevent rerender

### DIFF
--- a/src/pages/benchmarks/[benchmark_id]/index.tsx
+++ b/src/pages/benchmarks/[benchmark_id]/index.tsx
@@ -71,7 +71,7 @@ const BenchmarkPage = () => {
   const [currentTrialIdx, setCurrentTrialIdx] = useState(0);
   const currentTrial = task?.trials[currentTrialIdx] || null;
 
-  const trialAddedRef = useRef(false);
+  const trialAddedRef = useRef<boolean>(false);
 
   const hasInputChanged =
     currentTrial?.notes !== notesInputValue ||

--- a/src/pages/benchmarks/[benchmark_id]/index.tsx
+++ b/src/pages/benchmarks/[benchmark_id]/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import Counter from "@/components/counter/counter";
 import ParaNav from "@/components/paraNav/ParaNav";
 import Link from "next/link";
@@ -71,7 +71,7 @@ const BenchmarkPage = () => {
   const [currentTrialIdx, setCurrentTrialIdx] = useState(0);
   const currentTrial = task?.trials[currentTrialIdx] || null;
 
-  const [trialAdded, setTrialAdded] = useState(false);
+  const trialAddedRef = useRef(false);
 
   const hasInputChanged =
     currentTrial?.notes !== notesInputValue ||
@@ -108,7 +108,7 @@ const BenchmarkPage = () => {
   // Creates a new data collection instance (if there are none in progress)
   useEffect(() => {
     if (
-      !trialAdded &&
+      !trialAddedRef.current &&
       !addTrialMutation.isLoading &&
       !taskIsLoading &&
       task &&
@@ -121,9 +121,9 @@ const BenchmarkPage = () => {
         unsuccess: 0,
         notes: "",
       });
-      setTrialAdded(true);
+      trialAddedRef.current = true;
     }
-  }, [task, addTrialMutation, taskIsLoading, trialAdded]);
+  }, [task, addTrialMutation, taskIsLoading]);
 
   const handleUpdate = (updates: DataUpdate) => {
     //Can only update if we're on the most recent trial


### PR DESCRIPTION
Behavior described in issue #468 is no longer occuring. 
Source of the problem was that useEffect was causing a rerender of the benchmark component in development.