### PR TITLE
Connect Goal Benchmark page to Collect Data page

### DIFF
--- a/src/components/benchmarks/BenchmarkListElement.tsx
+++ b/src/components/benchmarks/BenchmarkListElement.tsx
@@ -151,15 +151,9 @@ const BenchmarkListElement = ({
                   textAlign: "center",
                 }}
               >
-                {/* Placeholder href to replace with actual path */}
-                <Button
-                  onClick={() => {
-                    alert("To be implemented");
-                  }}
-                  className={$button.tertiary}
-                >
-                  Collect Data
-                </Button>
+                <Link href={`/benchmarks/${benchmark.benchmark_id}`}>
+                  <Button className={$button.tertiary}>Collect Data</Button>
+                </Link>
               </Box>
               <Box
                 sx={{

--- a/src/components/taskCard/taskCard.tsx
+++ b/src/components/taskCard/taskCard.tsx
@@ -4,6 +4,7 @@ import { differenceInWeeks, format } from "date-fns";
 import Link from "next/link";
 import { useMemo } from "react";
 import $taskCard from "./TaskCard.module.css";
+import { Button } from "@mui/material";
 
 interface ParaTaskCard {
   // this should be based on TaskData, maybe have some Omit's.
@@ -75,12 +76,12 @@ const TaskCard = ({ task, isPara }: TaskCardProps) => {
         <div style={{ display: "flex", gap: "1rem" }}>
           {/* Para smaller screen view can click on card instead */}
           {!isPara ? (
-            <Link
-              href={`/benchmarks/${task.benchmark_id}`}
-              className={`${$button.secondary}`}
+            <Button
+              onClick={() => alert("to be implemented")}
+              className={$button.secondary}
             >
               View benchmark
-            </Link>
+            </Button>
           ) : null}
 
           <Link


### PR DESCRIPTION
Connect Goal Benchmark page to Collect Data page

We also intentionally "broke" the Assigned Students which was originally linking View Data to the Collect Data page. This is to not give the impression that the View Data page is done.

Co-authored by: Nick Visutsithiwong <2823112+nickvisut@users.noreply.github.com>